### PR TITLE
Exclude trips with no arrival or departure time set

### DIFF
--- a/tests/unit/services/test_stopservice.py
+++ b/tests/unit/services/test_stopservice.py
@@ -123,6 +123,13 @@ def test_old_trips__exclude(time_dot_time):
     assert stop_time_filter.remove(stop_time, DIRECTION) is True
 
 
+def test_trips_with_no_time__exclude():
+    stop_time = models.TripStopTime(arrival_time=None)
+    stop_time_filter = stopservice._TripStopTimeFilter("0", "10", "0")
+
+    assert stop_time_filter.remove(stop_time, DIRECTION) is True
+
+
 def test_old_trips__include_when_no_lower_bound(time_dot_time):
     stop_time = models.TripStopTime(arrival_time=TIME_1)
     time_dot_time.return_value = TIME_4.timestamp()

--- a/transiter/services/stopservice.py
+++ b/transiter/services/stopservice.py
@@ -182,6 +182,10 @@ class _TripStopTimeFilter:
         return result
 
     def _remove_helper(self, trip_stop_time: models.TripStopTime, direction):
+        # If the trip doesn't have an arrival or departure time, remove.
+        if trip_stop_time.get_time() is None:
+            return True
+
         trip_time = trip_stop_time.get_time().timestamp()
         # If the trip is before the inclusion interval, remove.
         if self._inclusion_interval_start is not None and (


### PR DESCRIPTION
There appear to be some cases where a Trip has neither arrival nor departure times set. This causes the `stops/{STOP_ID}` endpoint to fail with the error below.

I am not sure if this is a feed corruption issue or expected behavior in some cases, but in either case, filtering out such trips seems to be the correct behavior.

```
❯ curl -X GET $TRANSITER_SERVER'/systems/us-ny-subway/stops/A31-L01'
{
  "type": "UNEXPECTED_ERROR",
  "code": "T011",
  "message": "There was an unexpected error. This generally indicates a bug in Transiter",
  "parameters": {
    "type": "AttributeError",
    "message": "'NoneType' object has no attribute 'timestamp'",
    "stack_trace": [
      "Traceback (most recent call last):",
      "  File \"/usr/local/lib/python3.8/site-packages/flask/app.py\", line 1950, in full_dispatch_request",
      "    rv = self.dispatch_request()",
      "  File \"/usr/local/lib/python3.8/site-packages/flask/app.py\", line 1936, in dispatch_request",
      "    return self.view_functions[rule.endpoint](**req.view_args)",
      "  File \"<decorator-gen-52>\", line 2, in get_in_system_by_id",
      "  File \"/usr/local/lib/python3.8/site-packages/transiter/http/httpmanager.py\", line 136, in _json_response",
      "    response = func(*args, **kwargs)",
      "  File \"/usr/local/lib/python3.8/site-packages/transiter/http/endpoints/stopendpoints.py\", line 111, in get_in_system_by_id",
      "    return stopservice.get_in_system_by_id(",
      "  File \"<decorator-gen-48>\", line 2, in get_in_system_by_id",
      "  File \"/usr/local/lib/python3.8/site-packages/transiter/db/dbconnection.py\", line 106, in unit_of_work",
      "    return func(*args, **kw)",
      "  File \"/usr/local/lib/python3.8/site-packages/transiter/services/stopservice.py\", line 153, in get_in_system_by_id",
      "    if stop_time_filter.remove(trip_stop_time, direction):",
      "  File \"/usr/local/lib/python3.8/site-packages/transiter/services/stopservice.py\", line 177, in remove",
      "    result = self._remove_helper(trip_stop_time, direction)",
      "  File \"/usr/local/lib/python3.8/site-packages/transiter/services/stopservice.py\", line 185, in _remove_helper",
      "    trip_time = trip_stop_time.get_time().timestamp()",
      "AttributeError: 'NoneType' object has no attribute 'timestamp'"
    ]
  }
}
```