### PR TITLE
Add Gzip support for public HTTP endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 require (
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
+	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/bytecodealliance/wasmtime-go/v5 v5.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cubicdaiya/gonp v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZC
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
+github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
+github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220626175859-9abda183db8e h1:bt6SW1eSSvdmmsG0KqyxYXorcTnFBTX7hfVR1+68+jg=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220626175859-9abda183db8e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jamespfennell/transiter/internal/scheduler"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
+	"github.com/NYTimes/gziphandler"
 )
 
 type RunArgs struct {
@@ -116,7 +117,7 @@ func Run(ctx context.Context, args RunArgs) error {
 				h.Handle("/metrics", monitoring.Handler())
 			}
 			log.Printf("Public HTTP API listening on %s\n", args.PublicHTTPAddr)
-			_ = http.ListenAndServe(args.PublicHTTPAddr, h)
+			_ = http.ListenAndServe(args.PublicHTTPAddr, gziphandler.GzipHandler(h))
 			log.Printf("Public HTTP API stopped")
 		}()
 	}


### PR DESCRIPTION
Allow Gzip compression on the public HTTP endpoint when client accepts it. This significantly reduces data transfer - for example, calling `/stops` for the `us-ny-buses` system reduces transfer size from 1.67 MB to less than 40 kB.