### PR TITLE
Allow the maxiumum number of returned stops to be configured

### DIFF
--- a/internal/public/endpoints/context.go
+++ b/internal/public/endpoints/context.go
@@ -10,9 +10,16 @@ import (
 	"github.com/jamespfennell/transiter/internal/public/reference"
 )
 
+type EndpointOptions struct {
+	// The maximum number of stops that can be returned in a single request.
+	// Defaults to 100.
+	MaxStopsPerRequest int32
+}
+
 type Context struct {
-	Querier   db.Querier
-	Reference reference.Generator
+	Querier         db.Querier
+	Reference       reference.Generator
+	EndpointOptions EndpointOptions
 }
 
 func getSystem(ctx context.Context, querier db.Querier, id string) (db.System, error) {

--- a/internal/public/endpoints/stop.go
+++ b/internal/public/endpoints/stop.go
@@ -2,6 +2,7 @@ package endpoints
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -21,7 +22,10 @@ func ListStops(ctx context.Context, r *Context, req *api.ListStopsRequest) (*api
 	if err != nil {
 		return nil, err
 	}
-	numStops := int32(100)
+	numStops := r.EndpointOptions.MaxStopsPerRequest
+	if numStops <= 0 {
+		numStops = math.MaxInt32
+	}
 	if req.Limit != nil && *req.Limit < numStops {
 		numStops = *req.Limit
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jamespfennell/transiter/internal/gen/api"
 	"github.com/jamespfennell/transiter/internal/monitoring"
 	"github.com/jamespfennell/transiter/internal/public"
+	"github.com/jamespfennell/transiter/internal/public/endpoints"
 	"github.com/jamespfennell/transiter/internal/public/errors"
 	"github.com/jamespfennell/transiter/internal/public/reference"
 	"github.com/jamespfennell/transiter/internal/scheduler"
@@ -37,6 +38,7 @@ type RunArgs struct {
 	EnablePublicMetrics bool
 	EnablePprof         bool
 	ReadOnly            bool
+	MaxStopsPerRequest  int32
 }
 
 func Run(ctx context.Context, args RunArgs) error {
@@ -86,7 +88,9 @@ func Run(ctx context.Context, args RunArgs) error {
 		s = realScheduler
 	}
 
-	publicService := public.New(pool)
+	publicService := public.New(pool, &endpoints.EndpointOptions{
+		MaxStopsPerRequest: args.MaxStopsPerRequest,
+	})
 	adminService := admin.New(pool, s)
 
 	if realScheduler != nil {

--- a/transiter.go
+++ b/transiter.go
@@ -172,6 +172,11 @@ func main() {
 						Usage: "Maximum size of the Postgres connection pool",
 						Value: 50,
 					},
+					&cli.Int64Flag{
+						Name:  "max-stops-per-request",
+						Usage: "Maximum number of stops that will be returned in a single list stops request. Specifying a value <= 0 will disable the limit.",
+						Value: 100,
+					},
 				},
 				Action: func(c *cli.Context) error {
 					args := server.RunArgs{
@@ -185,6 +190,7 @@ func main() {
 						EnablePublicMetrics: c.Bool("enable-public-metrics"),
 						ReadOnly:            c.Bool("read-only"),
 						EnablePprof:         c.Bool("enable-pprof"),
+						MaxStopsPerRequest:  int32(c.Int64("max-stops-per-request")),
 					}
 					ctx, cancel := context.WithCancel(c.Context)
 					ch := make(chan os.Signal, 1)


### PR DESCRIPTION
This change removes the 100 stop limit when using a `DISTANCE` search with  the `/stops` endpoint. While this may not be performant for large distances, searches for the `us-ny-subway` of approximately 2/3 miles in Manhattan exceeds this limit, and are reasonably fast.

The main concern I have with this change that it could, in theory, be used adversarially. For example, if the `/stops` endpoint is directly exposed, large searches could degrade the service. This could be mitigated by either:

1. Allowing the server to be configured with a hard limit (defaulting to 100) and then letting server operators decide what they want to allow
2. Keeping a hard coded limit but increasing it