### PR TITLE
Fix typo in `NyctSubwayCsv` feed type constant

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	NyctSubwayCsv = "NYC_SUBWAY_CSV"
+	NyctSubwayCsv = "NYCT_SUBWAY_CSV"
 	GtfsRealtime  = "GTFS_REALTIME"
 	GtfsStatic    = "GTFS_STATIC"
 )


### PR DESCRIPTION
Fix typo in `NyctSubwayCsv` feed type constant. This typo causes installations of the `us-ny-subway` system to fail.