### PR TITLE
Use `copyfrom` for updating vehicles

### DIFF
--- a/db/queries/vehicle_queries.sql
+++ b/db/queries/vehicle_queries.sql
@@ -1,28 +1,8 @@
--- name: InsertVehicle :exec
+-- name: InsertVehicle :copyfrom
 INSERT INTO vehicle
     (id, system_pk, trip_pk, label, license_plate, current_status, latitude, longitude, bearing, odometer, speed, congestion_level, updated_at, current_stop_pk, current_stop_sequence, occupancy_status, feed_pk, occupancy_percentage)
 VALUES
     (sqlc.arg(id), sqlc.arg(system_pk), sqlc.arg(trip_pk), sqlc.arg(label), sqlc.arg(license_plate), sqlc.arg(current_status), sqlc.arg(latitude), sqlc.arg(longitude), sqlc.arg(bearing), sqlc.arg(odometer), sqlc.arg(speed), sqlc.arg(congestion_level), sqlc.arg(updated_at), sqlc.arg(current_stop_pk), sqlc.arg(current_stop_sequence), sqlc.arg(occupancy_status), sqlc.arg(feed_pk), sqlc.arg(occupancy_percentage));
-
--- name: UpdateVehicle :exec
-UPDATE vehicle
-SET trip_pk = sqlc.arg(trip_pk),
-    label = sqlc.arg(label),
-    license_plate = sqlc.arg(license_plate),
-    current_status = sqlc.arg(current_status),
-    latitude = sqlc.arg(latitude),
-    longitude = sqlc.arg(longitude),
-    bearing = sqlc.arg(bearing),
-    odometer = sqlc.arg(odometer),
-    speed = sqlc.arg(speed),
-    congestion_level = sqlc.arg(congestion_level),
-    updated_at = sqlc.arg(updated_at),
-    current_stop_pk = sqlc.arg(current_stop_pk),
-    current_stop_sequence = sqlc.arg(current_stop_sequence),
-    occupancy_status = sqlc.arg(occupancy_status),
-    feed_pk = sqlc.arg(feed_pk),
-    occupancy_percentage = sqlc.arg(occupancy_percentage)
-WHERE vehicle.pk = sqlc.arg(pk);
 
 -- name: ListVehicles :many
 SELECT vehicle.*,
@@ -83,13 +63,14 @@ LEFT JOIN trip ON vehicle.trip_pk = trip.pk
 LEFT JOIN route ON trip.route_pk = route.pk
 WHERE vehicle.system_pk = sqlc.arg(system_pk) AND vehicle.id = sqlc.arg(vehicle_id);
 
--- name: ListVehicleUniqueColumns :many
-SELECT id, pk, trip_pk FROM vehicle
+-- name: MapTripPkToVehicleID :many
+SELECT id, trip_pk FROM vehicle
 WHERE id = ANY(sqlc.arg(vehicle_ids)::text[])
 AND system_pk = sqlc.arg(system_pk);
 
--- name: DeleteStaleVehicles :exec
+-- name: DeleteVehicles :exec
 DELETE FROM vehicle
-WHERE
-  feed_pk = sqlc.arg(feed_pk)
-  AND NOT id = ANY(sqlc.arg(active_vehicle_ids)::text[]);
+WHERE system_pk = sqlc.arg(system_pk)
+  AND (feed_pk = sqlc.arg(feed_pk)
+       OR vehicle.id = ANY(sqlc.arg(vehicle_ids)::text[])
+       OR trip_pk = ANY(sqlc.arg(trip_pks)::bigint[]));

--- a/internal/db/dbwrappers/dbwrappers.go
+++ b/internal/db/dbwrappers/dbwrappers.go
@@ -186,28 +186,26 @@ func ListStopTimesForUpdate(ctx context.Context, querier db.Querier, tripUIDToPk
 	return m, nil
 }
 
-func MapVehicleIDToPkandTripPkToVehicleID(
+func MapTripPkToVehicleID(
 	ctx context.Context,
 	querier db.Querier,
 	systemPk int64,
-	vehicleIDs []string) (map[string]int64, map[int64]string, error) {
-	rows, err := querier.ListVehicleUniqueColumns(ctx, db.ListVehicleUniqueColumnsParams{
+	vehicleIDs []string) (map[int64]string, error) {
+	rows, err := querier.MapTripPkToVehicleID(ctx, db.MapTripPkToVehicleIDParams{
 		SystemPk:   systemPk,
 		VehicleIds: vehicleIDs,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	vehicleIDToPk := map[string]int64{}
 	tripPkToVehicleID := map[int64]string{}
 	for _, row := range rows {
-		vehicleIDToPk[row.ID.String] = row.Pk
 		if row.TripPk.Valid {
 			tripPkToVehicleID[row.TripPk.Int64] = row.ID.String
 		}
 	}
-	return vehicleIDToPk, tripPkToVehicleID, nil
+	return tripPkToVehicleID, nil
 }
 
 func MapScheduledTripIDToPkInSystem(ctx context.Context, queries db.Querier, systemPk int64, scheduledTripIDs ...[]string) (map[string]int64, error) {

--- a/internal/gen/db/copyfrom.go
+++ b/internal/gen/db/copyfrom.go
@@ -169,3 +169,52 @@ func (r iteratorForInsertTripStopTime) Err() error {
 func (q *Queries) InsertTripStopTime(ctx context.Context, arg []InsertTripStopTimeParams) (int64, error) {
 	return q.db.CopyFrom(ctx, []string{"trip_stop_time"}, []string{"stop_pk", "trip_pk", "arrival_time", "arrival_delay", "arrival_uncertainty", "departure_time", "departure_delay", "departure_uncertainty", "stop_sequence", "track", "headsign", "past"}, &iteratorForInsertTripStopTime{rows: arg})
 }
+
+// iteratorForInsertVehicle implements pgx.CopyFromSource.
+type iteratorForInsertVehicle struct {
+	rows                 []InsertVehicleParams
+	skippedFirstNextCall bool
+}
+
+func (r *iteratorForInsertVehicle) Next() bool {
+	if len(r.rows) == 0 {
+		return false
+	}
+	if !r.skippedFirstNextCall {
+		r.skippedFirstNextCall = true
+		return true
+	}
+	r.rows = r.rows[1:]
+	return len(r.rows) > 0
+}
+
+func (r iteratorForInsertVehicle) Values() ([]interface{}, error) {
+	return []interface{}{
+		r.rows[0].ID,
+		r.rows[0].SystemPk,
+		r.rows[0].TripPk,
+		r.rows[0].Label,
+		r.rows[0].LicensePlate,
+		r.rows[0].CurrentStatus,
+		r.rows[0].Latitude,
+		r.rows[0].Longitude,
+		r.rows[0].Bearing,
+		r.rows[0].Odometer,
+		r.rows[0].Speed,
+		r.rows[0].CongestionLevel,
+		r.rows[0].UpdatedAt,
+		r.rows[0].CurrentStopPk,
+		r.rows[0].CurrentStopSequence,
+		r.rows[0].OccupancyStatus,
+		r.rows[0].FeedPk,
+		r.rows[0].OccupancyPercentage,
+	}, nil
+}
+
+func (r iteratorForInsertVehicle) Err() error {
+	return nil
+}
+
+func (q *Queries) InsertVehicle(ctx context.Context, arg []InsertVehicleParams) (int64, error) {
+	return q.db.CopyFrom(ctx, []string{"vehicle"}, []string{"id", "system_pk", "trip_pk", "label", "license_plate", "current_status", "latitude", "longitude", "bearing", "odometer", "speed", "congestion_level", "updated_at", "current_stop_pk", "current_stop_sequence", "occupancy_status", "feed_pk", "occupancy_percentage"}, &iteratorForInsertVehicle{rows: arg})
+}

--- a/internal/gen/db/querier.go
+++ b/internal/gen/db/querier.go
@@ -27,11 +27,11 @@ type Querier interface {
 	DeleteStaleRoutes(ctx context.Context, arg DeleteStaleRoutesParams) error
 	DeleteStaleStops(ctx context.Context, arg DeleteStaleStopsParams) error
 	DeleteStaleTrips(ctx context.Context, arg DeleteStaleTripsParams) ([]int64, error)
-	DeleteStaleVehicles(ctx context.Context, arg DeleteStaleVehiclesParams) error
 	DeleteStopHeadsignRules(ctx context.Context, feedPk int64) error
 	DeleteSystem(ctx context.Context, pk int64) error
 	DeleteTransfers(ctx context.Context, feedPk int64) error
 	DeleteTripStopTimes(ctx context.Context, pks []int64) error
+	DeleteVehicles(ctx context.Context, arg DeleteVehiclesParams) error
 	EstimateHeadwaysForRoutes(ctx context.Context, arg EstimateHeadwaysForRoutesParams) ([]EstimateHeadwaysForRoutesRow, error)
 	GetAgency(ctx context.Context, arg GetAgencyParams) (Agency, error)
 	GetAlertInSystem(ctx context.Context, arg GetAlertInSystemParams) (Alert, error)
@@ -67,7 +67,7 @@ type Querier interface {
 	InsertTransfer(ctx context.Context, arg InsertTransferParams) error
 	InsertTrip(ctx context.Context, arg InsertTripParams) (int64, error)
 	InsertTripStopTime(ctx context.Context, arg []InsertTripStopTimeParams) (int64, error)
-	InsertVehicle(ctx context.Context, arg InsertVehicleParams) error
+	InsertVehicle(ctx context.Context, arg []InsertVehicleParams) (int64, error)
 	ListActiveAlertsForAgencies(ctx context.Context, arg ListActiveAlertsForAgenciesParams) ([]ListActiveAlertsForAgenciesRow, error)
 	// ListActiveAlertsForRoutes returns preview information about active alerts for the provided routes.
 	ListActiveAlertsForRoutes(ctx context.Context, arg ListActiveAlertsForRoutesParams) ([]ListActiveAlertsForRoutesRow, error)
@@ -106,7 +106,6 @@ type Querier interface {
 	ListTripStopTimesByStops(ctx context.Context, stopPks []int64) ([]ListTripStopTimesByStopsRow, error)
 	ListTripStopTimesForUpdate(ctx context.Context, tripPks []int64) ([]ListTripStopTimesForUpdateRow, error)
 	ListTrips(ctx context.Context, arg ListTripsParams) ([]ListTripsRow, error)
-	ListVehicleUniqueColumns(ctx context.Context, arg ListVehicleUniqueColumnsParams) ([]ListVehicleUniqueColumnsRow, error)
 	ListVehicles(ctx context.Context, arg ListVehiclesParams) ([]ListVehiclesRow, error)
 	ListVehicles_Geographic(ctx context.Context, arg ListVehicles_GeographicParams) ([]ListVehicles_GeographicRow, error)
 	MapAgencyPkToId(ctx context.Context, systemPk int64) ([]MapAgencyPkToIdRow, error)
@@ -117,6 +116,7 @@ type Querier interface {
 	MapStopPkToChildPks(ctx context.Context, stopPks []int64) ([]MapStopPkToChildPksRow, error)
 	MapStopPkToDescendentPks(ctx context.Context, stopPks []int64) ([]MapStopPkToDescendentPksRow, error)
 	MapTripIDToPkInSystem(ctx context.Context, arg MapTripIDToPkInSystemParams) ([]MapTripIDToPkInSystemRow, error)
+	MapTripPkToVehicleID(ctx context.Context, arg MapTripPkToVehicleIDParams) ([]MapTripPkToVehicleIDRow, error)
 	MarkFailedUpdate(ctx context.Context, arg MarkFailedUpdateParams) error
 	MarkSkippedUpdate(ctx context.Context, arg MarkSkippedUpdateParams) error
 	MarkSuccessfulUpdate(ctx context.Context, arg MarkSuccessfulUpdateParams) error
@@ -131,7 +131,6 @@ type Querier interface {
 	UpdateSystemStatus(ctx context.Context, arg UpdateSystemStatusParams) error
 	UpdateTrip(ctx context.Context, arg []UpdateTripParams) *UpdateTripBatchResults
 	UpdateTripStopTime(ctx context.Context, arg UpdateTripStopTimeParams) error
-	UpdateVehicle(ctx context.Context, arg UpdateVehicleParams) error
 }
 
 var _ Querier = (*Queries)(nil)


### PR DESCRIPTION
# Overview

Use `copyfrom` when updating vehicle entities. This has 2 advantages:

- Simpler implementation
- The NYC bus system vehicle updates are faster (see below performance comparison)

This change also adds additional tests to further verify multi-feed update behavior (i.e. that multiple feeds updating a system's vehicles don't interfere with each other).

# Performance comparison

Below shows metrics from before/after this change over the course of 10 feed updates.

## Single insert/update commands (current implementation)

```
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.005"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.01"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.025"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.05"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.1"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.25"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.5"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="1"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="2.5"} 8
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="5"} 9
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="10"} 10
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="+Inf"} 10
transiter_feed_update_database_latency_sum{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses"} 21.973
transiter_feed_update_database_latency_count{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses"} 10
```
## Using `copyfrom`:
```
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.005"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.01"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.025"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.05"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.1"} 0
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.25"} 8
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="0.5"} 8
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="1"} 9
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="2.5"} 10
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="5"} 10
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="10"} 10
transiter_feed_update_database_latency_bucket{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses",le="+Inf"} 10
transiter_feed_update_database_latency_sum{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses"} 3.8310000000000004
transiter_feed_update_database_latency_count{feed_id="vehicles",feed_type="GTFS_REALTIME",system_id="us-ny-buses"} 10
```
