### PR TITLE
Discard unknown fields when parsing Feed configs

### DIFF
--- a/docs/src/api/admin.md
+++ b/docs/src/api/admin.md
@@ -459,7 +459,7 @@ Message describing additional options for the GTFS realtime feeds.
 | nyct_trips_options | [GtfsRealtimeOptions.NyctTripsOptions](admin.md#GtfsRealtimeOptions.NyctTripsOptions) | 
 | nyct_alerts_options | [GtfsRealtimeOptions.NyctAlertsOptions](admin.md#GtfsRealtimeOptions.NyctAlertsOptions) | 
 | reassign_stop_sequences | bool | If true, stop sequences in the GTFS realtime feed data are ignored, and alternative stop sequences are generated and assigned by Transiter. This setting is designed for buggy GTFS realtime feeds in which stop sequences (incorrectly) change between updates. In many cases Transiter is able to generate stop sequences that are correct and stable across updates.<br /><br />This should not be used for systems where a trip can call at the same stop multiple times.
-| only_process_full_entities | bool | If true, only process entities in a feed if the message contains the full entity. This is useful for cases where there are multiple feeds for the same system, and some feeds contain only partial information about entities.
+| only_process_full_entities | bool | Deprecated: this field is ignored.
 
 
 

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jamespfennell/transiter/internal/convert"
 	"github.com/jamespfennell/transiter/internal/db/constants"
 	"github.com/jamespfennell/transiter/internal/gen/api"
 	"github.com/jamespfennell/transiter/internal/gen/db"
@@ -62,7 +63,7 @@ func (s *Service) GetSystemConfig(ctx context.Context, req *api.GetSystemConfigR
 		for _, feed := range feeds {
 			feed := feed
 			var feedConfig api.FeedConfig
-			if err := protojson.Unmarshal([]byte(feed.Config), &feedConfig); err != nil {
+			if err := convert.UnmarshalJSONAndDiscardUnknown([]byte(feed.Config), &feedConfig); err != nil {
 				return err
 			}
 			reply.Feeds = append(reply.Feeds, &feedConfig)

--- a/internal/convert/json.go
+++ b/internal/convert/json.go
@@ -1,0 +1,12 @@
+package convert
+
+import (
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func UnmarshalJSONAndDiscardUnknown(b []byte, m proto.Message) error {
+	return protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}.Unmarshal(b, m)
+}

--- a/internal/update/common/common.go
+++ b/internal/update/common/common.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jamespfennell/transiter/internal/gen/api"
 	"github.com/jamespfennell/transiter/internal/gen/db"
 	"golang.org/x/exp/slog"
+	"google.golang.org/protobuf/proto"
 )
 
 type UpdateContext struct {
@@ -45,4 +46,11 @@ func MapKeys[T comparable, V any](in map[T]V) []T {
 		out = append(out, t)
 	}
 	return out
+}
+
+func UnmarshallAndDiscardUnknown(b []byte, m proto.Message) error {
+	unmarshalOptions := proto.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
+	return unmarshalOptions.Unmarshal(b, m)
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jamespfennell/gtfs"
+	"github.com/jamespfennell/transiter/internal/convert"
 	"github.com/jamespfennell/transiter/internal/gen/api"
 	"github.com/jamespfennell/transiter/internal/gen/db"
 	"github.com/jamespfennell/transiter/internal/monitoring"
@@ -22,7 +23,6 @@ import (
 	"github.com/jamespfennell/transiter/internal/update/realtime"
 	"github.com/jamespfennell/transiter/internal/update/static"
 	"golang.org/x/exp/slog"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -119,7 +119,7 @@ func markSuccess(feedUpdate *api.FeedUpdate, status api.FeedUpdate_Status) (*api
 func run(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger, systemID string, feed db.Feed, force bool) (*api.FeedUpdate, error) {
 	feedUpdate := &api.FeedUpdate{}
 	var feedConfig api.FeedConfig
-	if err := protojson.Unmarshal([]byte(feed.Config), &feedConfig); err != nil {
+	if err := convert.UnmarshalJSONAndDiscardUnknown([]byte(feed.Config), &feedConfig); err != nil {
 		return markFailure(feedUpdate, api.FeedUpdate_FAILED_INVALID_FEED_CONFIG, fmt.Errorf("failed to parse feed config: %w", err))
 	}
 	NormalizeFeedConfig(&feedConfig)


### PR DESCRIPTION
Discard unknown fields when parsing Feed configs. This allows fields to be fully deprecated and removed from the proto definition while not breaking backwards compatibility.