### PR TITLE
Persist informed `Trip` and `RouteType` entities in `Alert`s

### DIFF
--- a/db/queries/alert_queries.sql
+++ b/db/queries/alert_queries.sql
@@ -1,13 +1,13 @@
 -- name: ListAlertPksAndHashes :many
-SELECT id, pk, hash FROM alert 
-WHERE id = ANY(sqlc.arg(alert_ids)::text[]) 
+SELECT id, pk, hash FROM alert
+WHERE id = ANY(sqlc.arg(alert_ids)::text[])
 AND system_pk = sqlc.arg(system_pk);
 
 -- name: InsertAlert :one
 INSERT INTO alert
     (id, system_pk, feed_pk, cause, effect, header, description, url, hash)
 VALUES
-    (sqlc.arg(id), sqlc.arg(system_pk), sqlc.arg(feed_pk), sqlc.arg(cause),sqlc.arg(effect), 
+    (sqlc.arg(id), sqlc.arg(system_pk), sqlc.arg(feed_pk), sqlc.arg(cause),sqlc.arg(effect),
      sqlc.arg(header), sqlc.arg(description), sqlc.arg(url), sqlc.arg(hash))
 RETURNING pk;
 
@@ -26,12 +26,18 @@ INSERT INTO alert_stop (alert_pk, stop_pk) VALUES (sqlc.arg(alert_pk), sqlc.arg(
 -- name: InsertAlertRoute :exec
 INSERT INTO alert_route (alert_pk, route_pk) VALUES (sqlc.arg(alert_pk), sqlc.arg(route_pk));
 
+-- name: InsertAlertTrip :exec
+INSERT INTO alert_trip (alert_pk, trip_pk, scheduled_trip_pk) VALUES (sqlc.arg(alert_pk), sqlc.narg(trip_pk), sqlc.narg(scheduled_trip_pk));
+
+-- name: InsertAlertRouteType :exec
+INSERT INTO alert_route_type (alert_pk, route_type) VALUES (sqlc.arg(alert_pk), sqlc.arg(route_type));
+
 -- name: DeleteAlerts :exec
 DELETE FROM alert WHERE pk = ANY(sqlc.arg(alert_pks)::bigint[]);
 
 -- name: DeleteStaleAlerts :exec
 DELETE FROM alert
-WHERE 
+WHERE
     alert.feed_pk = sqlc.arg(feed_pk)
     AND NOT alert.pk = ANY(sqlc.arg(updated_alert_pks)::bigint[]);
 
@@ -107,3 +113,49 @@ WHERE stop.pk = ANY(sqlc.arg(stop_pks)::bigint[])
         OR alert_active_period.ends_at IS NULL
     )
 ORDER BY alert.id ASC;
+
+-- name: ListAlertsWithActivePeriodsAndAllInformedEntities :many
+SELECT alert.id,
+       alert.cause,
+       alert.effect,
+       alert.header,
+       alert.description,
+       alert.url,
+       COALESCE(
+               (ARRAY_AGG(
+                DISTINCT tstzrange(alert_active_period.starts_at::timestamptz, alert_active_period.ends_at::timestamptz, '[)')
+                ORDER BY tstzrange(alert_active_period.starts_at::timestamptz, alert_active_period.ends_at::timestamptz, '[)'))
+                FILTER ( WHERE alert_active_period.starts_at IS NOT NULL OR alert_active_period.ends_at IS NOT NULL )),
+               ARRAY []::tstzrange[])::tstzrange[] AS active_periods,
+       COALESCE(
+               (ARRAY_AGG(DISTINCT agency.id ORDER BY agency.id) FILTER (where agency.id is not null)),
+               ARRAY []::text[])::text[]           AS agencies,
+       COALESCE(
+               (ARRAY_AGG(DISTINCT route.id ORDER BY route.id) FILTER (where route.id is not null)),
+               ARRAY []::text[])::text[]           AS routes,
+       COALESCE(
+               (ARRAY_AGG(DISTINCT stop.id ORDER BY stop.id) FILTER (where stop.id is not null)),
+               ARRAY []::text[])::text[]           AS stops,
+       COALESCE(
+               (ARRAY_AGG(DISTINCT trip.id ORDER BY trip.id) FILTER (where trip.id is not null)),
+               ARRAY []::text[])::text[]           AS trips,
+       COALESCE(
+               (ARRAY_AGG(DISTINCT scheduled_trip.id ORDER BY scheduled_trip.id) FILTER (where scheduled_trip.id is not null)),
+               ARRAY []::text[])::text[]           AS scheduled_trips,
+       COALESCE(
+               (ARRAY_AGG(DISTINCT route_type ORDER BY route_type) FILTER (where route_type is not null)),
+               ARRAY []::text[])::text[]           AS route_types
+FROM alert
+         LEFT JOIN alert_active_period ON alert.pk = alert_active_period.alert_pk
+         LEFT JOIN alert_agency ON alert.pk = alert_agency.alert_pk
+         LEFT JOIN agency ON alert_agency.agency_pk = agency.pk
+         LEFT JOIN alert_route ON alert.pk = alert_route.alert_pk
+         LEFT JOIN route ON alert_route.route_pk = route.pk
+         LEFT JOIN alert_stop ON alert.pk = alert_stop.alert_pk
+         LEFT JOIN stop ON alert_stop.stop_pk = stop.pk
+         LEFT JOIN alert_trip ON alert.pk = alert_trip.alert_pk
+         LEFT JOIN trip ON alert_trip.trip_pk = trip.pk
+         LEFT JOIN scheduled_trip ON alert_trip.scheduled_trip_pk = scheduled_trip.pk
+         LEFT JOIN alert_route_type ON alert.pk = alert_route_type.alert_pk
+WHERE alert.system_pk = sqlc.arg(system_pk)
+GROUP BY alert.id, alert.cause, alert.effect, alert.header, alert.description, alert.url;

--- a/db/schema/007_alert_informed_entity_update.sql
+++ b/db/schema/007_alert_informed_entity_update.sql
@@ -1,0 +1,15 @@
+ALTER TABLE alert_trip DROP CONSTRAINT fk_alert_trip_trip_pk;
+ALTER TABLE alert_trip
+    ADD CONSTRAINT fk_alert_trip_pk FOREIGN KEY (trip_pk) REFERENCES trip(pk) ON DELETE SET NULL;
+ALTER TABLE alert_trip ALTER COLUMN trip_pk DROP NOT NULL;
+
+ALTER TABLE alert_trip
+ADD COLUMN scheduled_trip_pk BIGINT REFERENCES scheduled_trip(pk) ON DELETE SET NULL;
+
+CREATE TABLE alert_route_type (
+    alert_pk BIGINT NOT NULL,
+    route_type character varying NOT NULL
+);
+
+ALTER TABLE alert_route_type
+    ADD CONSTRAINT fk_alert_route_type_alert_pk FOREIGN KEY(alert_pk) REFERENCES alert(pk) ON DELETE CASCADE;

--- a/internal/gen/db/models.go
+++ b/internal/gen/db/models.go
@@ -52,14 +52,20 @@ type AlertRoute struct {
 	RoutePk int64
 }
 
+type AlertRouteType struct {
+	AlertPk   int64
+	RouteType string
+}
+
 type AlertStop struct {
 	AlertPk int64
 	StopPk  int64
 }
 
 type AlertTrip struct {
-	AlertPk int64
-	TripPk  int64
+	AlertPk         int64
+	TripPk          pgtype.Int8
+	ScheduledTripPk pgtype.Int8
 }
 
 type Feed struct {

--- a/internal/gen/db/querier.go
+++ b/internal/gen/db/querier.go
@@ -50,7 +50,9 @@ type Querier interface {
 	InsertAlertActivePeriod(ctx context.Context, arg InsertAlertActivePeriodParams) error
 	InsertAlertAgency(ctx context.Context, arg InsertAlertAgencyParams) error
 	InsertAlertRoute(ctx context.Context, arg InsertAlertRouteParams) error
+	InsertAlertRouteType(ctx context.Context, arg InsertAlertRouteTypeParams) error
 	InsertAlertStop(ctx context.Context, arg InsertAlertStopParams) error
+	InsertAlertTrip(ctx context.Context, arg InsertAlertTripParams) error
 	InsertFeed(ctx context.Context, arg InsertFeedParams) error
 	InsertRoute(ctx context.Context, arg InsertRouteParams) (int64, error)
 	InsertScheduledService(ctx context.Context, arg InsertScheduledServiceParams) (int64, error)
@@ -80,6 +82,7 @@ type Querier interface {
 	ListAlertPksAndHashes(ctx context.Context, arg ListAlertPksAndHashesParams) ([]ListAlertPksAndHashesRow, error)
 	ListAlertsInSystem(ctx context.Context, systemPk int64) ([]Alert, error)
 	ListAlertsInSystemAndByIDs(ctx context.Context, arg ListAlertsInSystemAndByIDsParams) ([]Alert, error)
+	ListAlertsWithActivePeriodsAndAllInformedEntities(ctx context.Context, systemPk int64) ([]ListAlertsWithActivePeriodsAndAllInformedEntitiesRow, error)
 	ListFeeds(ctx context.Context, systemPk int64) ([]Feed, error)
 	ListRoutes(ctx context.Context, systemPk int64) ([]Route, error)
 	ListRoutesByPk(ctx context.Context, routePks []int64) ([]ListRoutesByPkRow, error)


### PR DESCRIPTION
- Alter existing `alert_trip` table to allow referencing a `trip` and/or `scheduled_trip`
- Add new table `alert_route_type` to store route types affected by alerts
- Populate `alert_trip` and `alert_route_type` tables in `updateAlerts`
- Add unit test coverage for `Alert` ETL