### PR TITLE
Update public api GTFS format documentation

### DIFF
--- a/api/public.proto
+++ b/api/public.proto
@@ -833,7 +833,7 @@ message Stop {
   //
   // These are determined using the `informed_entity` field in
   // the [GTFS realtime alerts
-  // message](https://gtfs.org/realtime/feed-entities/service-alerts/#service-alerts).
+  // message](https://gtfs.org/realtime/reference/#message-alert).
   repeated Alert.Reference alerts = 18;
 
   // List of realtime stop times for this stop.
@@ -1195,7 +1195,7 @@ message Agency {
   //
   // These are determined using the `informed_entity` field in
   // the [GTFS realtime alerts
-  // message](https://gtfs.org/realtime/feed-entities/service-alerts/#service-alerts).
+  // message](https://gtfs.org/realtime/reference/#message-alert).
   repeated Alert.Reference alerts = 12;
 
   // Reference is the reference type for the agency resource.
@@ -1210,7 +1210,7 @@ message Agency {
 // The Alert resource.
 //
 // This resource corresponds to the [alert type in the GTFS realtime
-// specification](https://gtfs.org/realtime/feed-entities/service-alerts/#service-alerts).
+// specification](https://gtfs.org/realtime/reference/#message-alert).
 //
 // TODO; alphabetize the messages
 message Alert {
@@ -1245,7 +1245,7 @@ message Alert {
   Cause cause = 4;
 
   // Effect is the same as the [effect enum in the GTFS realtime
-  // specification](https://gtfs.org/realtime/feed-entities/service-alerts/#,
+  // specification](https://gtfs.org/realtime/feed-entities/service-alerts/#effect),
   // except `UNKNOWN_EFFECT` has value 0 instead of 1 to satisfy proto3 requirements.
   enum Effect {
     UNKNOWN_EFFECT = 0;

--- a/api/public.proto
+++ b/api/public.proto
@@ -6,15 +6,15 @@ This is the resource hierarchy:
 
 ```
 System
- |- Agency
- |- Alert
- |- Feed
- |- Route
- |   |- Trip
- |       |- Vehicle with no ID
- |- Stop
- |- Transfer
- |- Vehicle with ID
+|- Agency
+|- Alert
+|- Feed
+|- Route
+|   |- Trip
+|       |- Vehicle with no ID
+|- Stop
+|- Transfer
+|- Vehicle with ID
 ```
 
 For each resource there is a proto message type, a list endpoint, and a get endpoints.
@@ -34,10 +34,10 @@ For example, each route has an agency it is attached to.
 Each stop has a list of service maps, each of which contains a set of routes.
 In these situations the resource message contains a _reference_ to the other resource.
 The [Route](#route) message contains an agency reference, in the form of an [Agency.Reference](#agencyreference)
-  message.
+message.
 These reference messages contain at least enough information to uniquely identify the resource.
 However they also contain additional information that is considered generally useful;
-  thus, the [Stop.Reference](#stopreference) message contains the stop's name.
+thus, the [Stop.Reference](#stopreference) message contains the stop's name.
 What counts as "considered generally" is obviously very subjective and open to change.
 
 The following table summarizes all of the resources and their types.

--- a/api/public.proto
+++ b/api/public.proto
@@ -765,7 +765,7 @@ message ChildResources {
 // The Stop resource.
 //
 // This resource corresponds to the [stop type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs/reference#stopstxt).
+// specification](https://gtfs.org/schedule/reference/#stopstxt).
 // Most of the static fields in the resource come directly from the `stops.txt` table.
 // Transiter adds some additional related fields (transfers, alerts, stop times)
 //   and computed fields (service maps).
@@ -833,7 +833,7 @@ message Stop {
   //
   // These are determined using the `informed_entity` field in
   // the [GTFS realtime alerts
-  // message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+  // message](https://gtfs.org/realtime/feed-entities/service-alerts/#service-alerts).
   repeated Alert.Reference alerts = 18;
 
   // List of realtime stop times for this stop.
@@ -873,7 +873,7 @@ message Stop {
 //
 // A stop time is an event in which a trip calls at a stop.
 // This message corresponds to the [GTFS realtime `StopTimeUpdate`
-// message](https://developers.google.com/transit/gtfs-realtime/reference#message-stoptimeupdate)
+// message](https://gtfs.org/realtime/reference/#message-stoptimeupdate)
 message StopTime {
   // The stop.
   Stop.Reference stop = 1;
@@ -882,7 +882,7 @@ message StopTime {
 
   // Message describing the arrival or departure time of a stop time.
   // This corresponds to the [GTFS realtime `StopTimeEvent`
-  // message](https://developers.google.com/transit/gtfs-realtime/reference#message-stoptimeevent).
+  // message](https://gtfs.org/realtime/reference/#message-stoptimeevent).
   message EstimatedTime {
     optional int64 time = 1;
     optional int32 delay = 2;
@@ -937,7 +937,7 @@ message Trip {
 // The Vehicle resource.
 //
 // This resource corresponds to the [vehicle position type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-vehicleposition).
+// specification](https://gtfs.org/realtime/reference/#message-vehicleposition).
 message Vehicle {
   // A unique ID for the vehicle.
   string id = 1;
@@ -966,8 +966,8 @@ message Vehicle {
   // A reference to the vehicle's current stop.
   optional Stop.Reference stop = 9;
 
-  // Corresponds to [VehicleStopStatus](https://developers.google.com/
-  // transit/gtfs-realtime/reference#enum-vehiclestopstatus).
+  // Corresponds to [VehicleStopStatus](https://gtfs.org/realtime/reference/
+  // #enum-vehiclestopstatus).
   enum CurrentStatus {
     INCOMING_AT = 0;
     STOPPED_AT = 1;
@@ -979,8 +979,8 @@ message Vehicle {
   // The timestamp of the last update to the vehicle's position.
   optional int64 updated_at = 11;
 
-  // Corresponds to [CongestionLevel](https://developers.google.com/
-  // transit/gtfs-realtime/reference#enum-congestionlevel).
+  // Corresponds to [CongestionLevel](https://gtfs.org/realtime/reference/
+  // #enum-congestionlevel).
   enum CongestionLevel {
     UNKNOWN_CONGESTION_LEVEL = 0;
     RUNNING_SMOOTHLY = 1;
@@ -991,8 +991,8 @@ message Vehicle {
   // The vehicle's current congestion level.
   CongestionLevel congestion_level = 12;
 
-  // Corresponds to [OccupancyStatus](https://developers.google.com/
-  // transit/gtfs-realtime/reference#enum-occupancystatus).
+  // Corresponds to [OccupancyStatus](https://gtfs.org/realtime/reference/
+  // #enum-occupancystatus).
   enum OccupancyStatus {
     EMPTY = 0;
     MANY_SEATS_AVAILABLE = 1;
@@ -1018,7 +1018,7 @@ message Vehicle {
 // The Route resource.
 //
 // This resource corresponds to the [route type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs/reference#routestxt).
+// specification](https://gtfs.org/schedule/reference/#routestxt).
 // Most of the fields in the resource come directly from the `routes.txt` table.
 // Transiter adds some additional related fields (agency, alerts)
 //   and computed fields (estimated headway, service maps).
@@ -1088,7 +1088,7 @@ message Route {
   //
   // These are determined using the `informed_entity` field in
   // the [GTFS realtime alerts
-  // message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+  // message](https://gtfs.org/realtime/feed-entities/service-alerts/#service-alerts).
   repeated Alert.Reference alerts = 15;
 
   // An estimate of the interval of time between consecutive realtime trips, in seconds.
@@ -1162,7 +1162,7 @@ message Feed {
 // The Agency resource.
 //
 // This resource corresponds to the [agency type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs/reference#agencytxt).
+// specification](https://gtfs.org/schedule/reference/#agencytxt).
 // Most of the fields in the resource come directly from the `agency.txt` table.
 // Transiter adds some additional related fields (alerts).
 message Agency {
@@ -1195,7 +1195,7 @@ message Agency {
   //
   // These are determined using the `informed_entity` field in
   // the [GTFS realtime alerts
-  // message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+  // message](https://gtfs.org/realtime/feed-entities/service-alerts/#service-alerts).
   repeated Alert.Reference alerts = 12;
 
   // Reference is the reference type for the agency resource.
@@ -1210,12 +1210,12 @@ message Agency {
 // The Alert resource.
 //
 // This resource corresponds to the [alert type in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+// specification](https://gtfs.org/realtime/feed-entities/service-alerts/#service-alerts).
 //
 // TODO; alphabetize the messages
 message Alert {
   // ID of the alert. This corresponds to the [ID field in the feed entity
-  // message](https://developers.google.com/transit/gtfs-realtime/reference#message-feedentity)
+  // message](https://gtfs.org/realtime/reference/#message-feedentity)
   // corresponding to the alert.
   string id = 1;
   // Generic metadata about the alert resource.
@@ -1225,7 +1225,7 @@ message Alert {
   System.Reference system = 3;
 
   // Cause is the same as the [cause enum in the GTFS realtime
-  // specification](https://developers.google.com/transit/gtfs-realtime/reference#enum-cause),
+  // specification](https://gtfs.org/realtime/feed-entities/service-alerts/#cause),
   // except `UNKNOWN_CAUSE` has value 0 instead of 1 to satisfy proto3 requirements.
   enum Cause {
     UNKNOWN_CAUSE = 0;
@@ -1245,7 +1245,7 @@ message Alert {
   Cause cause = 4;
 
   // Effect is the same as the [effect enum in the GTFS realtime
-  // specification](https://developers.google.com/transit/gtfs-realtime/reference#enum-effect),
+  // specification](https://gtfs.org/realtime/feed-entities/service-alerts/#,
   // except `UNKNOWN_EFFECT` has value 0 instead of 1 to satisfy proto3 requirements.
   enum Effect {
     UNKNOWN_EFFECT = 0;
@@ -1265,7 +1265,7 @@ message Alert {
 
   // The active period message describes a period when an alert is active.
   // It corresponds the the [time range message in the GTFS realtime
-  // specification](https://developers.google.com/transit/gtfs-realtime/reference#message-timerange).
+  // specification](https://gtfs.org/realtime/reference/#message-timerange).
   message ActivePeriod {
     // Unix timestamp of the start time of the active period.
     // If not set, the alert be interpreted
@@ -1284,7 +1284,7 @@ message Alert {
 
   // The text message describes an alert header/description/URL in a specified language.
   // It corresponds the the [translation message in the GTFS realtime
-  // specification](https://developers.google.com/transit/gtfs-realtime/reference#message-translation).
+  // specification](https://gtfs.org/realtime/reference/#message-translation).
   message Text {
     // Content of the text.
     string text = 1;

--- a/docs/src/api/public_resources.md
+++ b/docs/src/api/public_resources.md
@@ -66,7 +66,7 @@ The public API is a read-only API so all of the resources come from somewhere el
 The Agency resource.
 
 This resource corresponds to the [agency type in the GTFS static
-specification](https://developers.google.com/transit/gtfs/reference#agencytxt).
+specification](https://gtfs.org/schedule/reference/#agencytxt).
 Most of the fields in the resource come directly from the `agency.txt` table.
 Transiter adds some additional related fields (alerts).
 	
@@ -85,7 +85,7 @@ Transiter adds some additional related fields (alerts).
 | fare_url | string | URL where tickets for the agency's services ban be bought. This is the `agency_fare_url` column in `agency.txt`.
 | email | string | Email address of the agency. This is the `agency_email` column in `agency.txt`.
 | routes | [Route.Reference](public_resources.md#Route.Reference) | 
-| alerts | [Alert.Reference](public_resources.md#Alert.Reference) | List of active alerts for the agency.<br /><br />These are determined using the `informed_entity` field in the [GTFS realtime alerts message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+| alerts | [Alert.Reference](public_resources.md#Alert.Reference) | List of active alerts for the agency.<br /><br />These are determined using the `informed_entity` field in the [GTFS realtime alerts message](https://gtfs.org/realtime/reference/#message-alert).
 
 
 
@@ -118,7 +118,7 @@ Reference is the reference type for the agency resource.
 The Alert resource.
 
 This resource corresponds to the [alert type in the GTFS realtime
-specification](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+specification](https://gtfs.org/realtime/reference/#message-alert).
 
 TODO; alphabetize the messages
 	
@@ -126,7 +126,7 @@ TODO; alphabetize the messages
 
 | Field | Type |  Description |
 | ----- | ---- | ----------- |
-| id | string | ID of the alert. This corresponds to the [ID field in the feed entity message](https://developers.google.com/transit/gtfs-realtime/reference#message-feedentity) corresponding to the alert.
+| id | string | ID of the alert. This corresponds to the [ID field in the feed entity message](https://gtfs.org/realtime/reference/#message-feedentity) corresponding to the alert.
 | resource | [Resource](public_resources.md#Resource) | Generic metadata about the alert resource.
 | system | [System.Reference](public_resources.md#System.Reference) | System corresponding to this alert. This is the parent resource in Transiter's resource hierarchy.
 | cause | [Alert.Cause](public_resources.md#Alert.Cause) | Cause of the alert. This corresponds to the `cause` field in the realtime alert message.
@@ -146,7 +146,7 @@ TODO; alphabetize the messages
 
 The active period message describes a period when an alert is active.
 It corresponds the the [time range message in the GTFS realtime
-specification](https://developers.google.com/transit/gtfs-realtime/reference#message-timerange).
+specification](https://gtfs.org/realtime/reference/#message-timerange).
 	
 
 
@@ -163,7 +163,7 @@ specification](https://developers.google.com/transit/gtfs-realtime/reference#mes
 #### Alert.Cause
 
 Cause is the same as the [cause enum in the GTFS realtime
-specification](https://developers.google.com/transit/gtfs-realtime/reference#enum-cause),
+specification](https://gtfs.org/realtime/feed-entities/service-alerts/#cause),
 except `UNKNOWN_CAUSE` has value 0 instead of 1 to satisfy proto3 requirements.
 	
 
@@ -189,7 +189,7 @@ except `UNKNOWN_CAUSE` has value 0 instead of 1 to satisfy proto3 requirements.
 #### Alert.Effect
 
 Effect is the same as the [effect enum in the GTFS realtime
-specification](https://developers.google.com/transit/gtfs-realtime/reference#enum-effect),
+specification](https://gtfs.org/realtime/feed-entities/service-alerts/#effect),
 except `UNKNOWN_EFFECT` has value 0 instead of 1 to satisfy proto3 requirements.
 	
 
@@ -234,7 +234,7 @@ Reference is the reference type for the agency resource.
 
 The text message describes an alert header/description/URL in a specified language.
 It corresponds the the [translation message in the GTFS realtime
-specification](https://developers.google.com/transit/gtfs-realtime/reference#message-translation).
+specification]().
 	
 
 
@@ -344,7 +344,7 @@ The resource message contains generic metadata that applies to all resources.
 The Route resource.
 
 This resource corresponds to the [route type in the GTFS static
-specification](https://developers.google.com/transit/gtfs/reference#routestxt).
+specification](https://gtfs.org/schedule/reference/#routestxt).
 Most of the fields in the resource come directly from the `routes.txt` table.
 Transiter adds some additional related fields (agency, alerts)
   and computed fields (estimated headway, service maps).
@@ -367,7 +367,7 @@ Transiter adds some additional related fields (agency, alerts)
 | continuous_drop_off | [Route.ContinuousPolicy](public_resources.md#Route.ContinuousPolicy) | Continuous dropoff policy. This is the `continuous_dropoff` column in `routes.txt`.
 | type | [Route.Type](public_resources.md#Route.Type) | Type of the route. This is the `route_type` column in `routes.txt`.
 | agency | [Agency.Reference](public_resources.md#Agency.Reference) | Agency this route is associated to.<br /><br />This is determined using the `agency_id` column in `routes.txt`.
-| alerts | [Alert.Reference](public_resources.md#Alert.Reference) | Active alerts for this route.<br /><br />These are determined using the `informed_entity` field in the [GTFS realtime alerts message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+| alerts | [Alert.Reference](public_resources.md#Alert.Reference) | Active alerts for this route.<br /><br />These are determined using the `informed_entity` field in the [GTFS realtime alerts message](https://gtfs.org/realtime/reference/#message-alert).
 | estimated_headway | int32 | An estimate of the interval of time between consecutive realtime trips, in seconds.<br /><br />If there is insufficient data to compute an estimate, the field will be empty.<br /><br />The estimate is computed as follows. For each stop that has realtime trips for the route, the list of arrival times for those trips is examined. The difference between consecutive arrival times is calculated. If there are `N` trips, there will be `N-1` such arrival time diffs. The estimated headway is the average of these diffs across all stops.
 | service_maps | [Route.ServiceMap](public_resources.md#Route.ServiceMap) | List of service maps for this route.
 
@@ -513,7 +513,7 @@ A point within the shape.
 The Stop resource.
 
 This resource corresponds to the [stop type in the GTFS static
-specification](https://developers.google.com/transit/gtfs/reference#stopstxt).
+specification](https://gtfs.org/schedule/reference/#stopstxt).
 Most of the static fields in the resource come directly from the `stops.txt` table.
 Transiter adds some additional related fields (transfers, alerts, stop times)
   and computed fields (service maps).
@@ -539,7 +539,7 @@ Transiter adds some additional related fields (transfers, alerts, stop times)
 | wheelchair_boarding | bool | If there is wheelchair boarding for this stop. This is the `wheelchair_boarding` column in `stops.txt`.
 | platform_code | string | Platform code of the stop. This is the `platform_code` column in `stops.txt`.
 | service_maps | [Stop.ServiceMap](public_resources.md#Stop.ServiceMap) | List of service maps for this stop.
-| alerts | [Alert.Reference](public_resources.md#Alert.Reference) | Active alerts for this stop.<br /><br />These are determined using the `informed_entity` field in the [GTFS realtime alerts message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+| alerts | [Alert.Reference](public_resources.md#Alert.Reference) | Active alerts for this stop.<br /><br />These are determined using the `informed_entity` field in the [GTFS realtime alerts message](https://gtfs.org/realtime/reference/#message-alert).
 | stop_times | [StopTime](public_resources.md#StopTime) | List of realtime stop times for this stop.<br /><br />A stop time is an event at which a trip calls at a stop.
 | transfers | [Transfer](public_resources.md#Transfer) | Transfers out of this stop.<br /><br />These are determined using the `from_stop_id` field in the GTFS static `transfers.txt` file.
 | headsign_rules | [Stop.HeadsignRule](public_resources.md#Stop.HeadsignRule) | List of headsign rules for this stop.
@@ -630,7 +630,7 @@ Message describing a realtime stop time.
 
 A stop time is an event in which a trip calls at a stop.
 This message corresponds to the [GTFS realtime `StopTimeUpdate`
-message](https://developers.google.com/transit/gtfs-realtime/reference#message-stoptimeupdate)
+message](https://gtfs.org/realtime/reference/#message-stoptimeupdate)
 	
 
 
@@ -654,7 +654,7 @@ message](https://developers.google.com/transit/gtfs-realtime/reference#message-s
 
 Message describing the arrival or departure time of a stop time.
 This corresponds to the [GTFS realtime `StopTimeEvent`
-message](https://developers.google.com/transit/gtfs-realtime/reference#message-stoptimeevent).
+message](https://gtfs.org/realtime/reference/#message-stoptimeevent).
 	
 
 
@@ -821,7 +821,7 @@ Reference is the reference type for the trip resource.
 The Vehicle resource.
 
 This resource corresponds to the [vehicle position type in the GTFS static
-specification](https://developers.google.com/transit/gtfs-realtime/reference#message-vehicleposition).
+specification](https://gtfs.org/realtime/reference/#message-vehicleposition).
 	
 
 
@@ -849,8 +849,7 @@ specification](https://developers.google.com/transit/gtfs-realtime/reference#mes
 
 #### Vehicle.CongestionLevel
 
-Corresponds to [CongestionLevel](https://developers.google.com/
-transit/gtfs-realtime/reference#enum-congestionlevel).
+Corresponds to [CongestionLevel](https://gtfs.org/realtime/reference/#enum-congestionlevel).
 	
 
 
@@ -867,8 +866,7 @@ transit/gtfs-realtime/reference#enum-congestionlevel).
 
 #### Vehicle.CurrentStatus
 
-Corresponds to [VehicleStopStatus](https://developers.google.com/
-transit/gtfs-realtime/reference#enum-vehiclestopstatus).
+Corresponds to [VehicleStopStatus](https://gtfs.org/realtime/reference/#enum-vehiclestopstatus).
 	
 
 
@@ -883,8 +881,7 @@ transit/gtfs-realtime/reference#enum-vehiclestopstatus).
 
 #### Vehicle.OccupancyStatus
 
-Corresponds to [OccupancyStatus](https://developers.google.com/
-transit/gtfs-realtime/reference#enum-occupancystatus).
+Corresponds to [OccupancyStatus](https://gtfs.org/realtime/reference/#enum-occupancystatus).
 	
 
 

--- a/docs/src/api/public_resources.md
+++ b/docs/src/api/public_resources.md
@@ -367,7 +367,7 @@ Transiter adds some additional related fields (agency, alerts)
 | continuous_drop_off | [Route.ContinuousPolicy](public_resources.md#Route.ContinuousPolicy) | Continuous dropoff policy. This is the `continuous_dropoff` column in `routes.txt`.
 | type | [Route.Type](public_resources.md#Route.Type) | Type of the route. This is the `route_type` column in `routes.txt`.
 | agency | [Agency.Reference](public_resources.md#Agency.Reference) | Agency this route is associated to.<br /><br />This is determined using the `agency_id` column in `routes.txt`.
-| alerts | [Alert.Reference](public_resources.md#Alert.Reference) | Active alerts for this route.<br /><br />These are determined using the `informed_entity` field in the [GTFS realtime alerts message](https://gtfs.org/realtime/reference/#message-alert).
+| alerts | [Alert.Reference](public_resources.md#Alert.Reference) | Active alerts for this route.<br /><br />These are determined using the `informed_entity` field in the [GTFS realtime alerts message](https://gtfs.org/realtime/feed-entities/service-alerts/#service-alerts).
 | estimated_headway | int32 | An estimate of the interval of time between consecutive realtime trips, in seconds.<br /><br />If there is insufficient data to compute an estimate, the field will be empty.<br /><br />The estimate is computed as follows. For each stop that has realtime trips for the route, the list of arrival times for those trips is examined. The difference between consecutive arrival times is calculated. If there are `N` trips, there will be `N-1` such arrival time diffs. The estimated headway is the average of these diffs across all stops.
 | service_maps | [Route.ServiceMap](public_resources.md#Route.ServiceMap) | List of service maps for this route.
 
@@ -849,7 +849,8 @@ specification](https://gtfs.org/realtime/reference/#message-vehicleposition).
 
 #### Vehicle.CongestionLevel
 
-Corresponds to [CongestionLevel](https://gtfs.org/realtime/reference/#enum-congestionlevel).
+Corresponds to [CongestionLevel](https://gtfs.org/realtime/reference/
+#enum-congestionlevel).
 	
 
 
@@ -866,7 +867,8 @@ Corresponds to [CongestionLevel](https://gtfs.org/realtime/reference/#enum-conge
 
 #### Vehicle.CurrentStatus
 
-Corresponds to [VehicleStopStatus](https://gtfs.org/realtime/reference/#enum-vehiclestopstatus).
+Corresponds to [VehicleStopStatus](https://gtfs.org/realtime/reference/
+#enum-vehiclestopstatus).
 	
 
 
@@ -881,7 +883,8 @@ Corresponds to [VehicleStopStatus](https://gtfs.org/realtime/reference/#enum-veh
 
 #### Vehicle.OccupancyStatus
 
-Corresponds to [OccupancyStatus](https://gtfs.org/realtime/reference/#enum-occupancystatus).
+Corresponds to [OccupancyStatus](https://gtfs.org/realtime/reference/
+#enum-occupancystatus).
 	
 
 

--- a/docs/src/api/public_resources.md
+++ b/docs/src/api/public_resources.md
@@ -234,7 +234,7 @@ Reference is the reference type for the agency resource.
 
 The text message describes an alert header/description/URL in a specified language.
 It corresponds the the [translation message in the GTFS realtime
-specification]().
+specification](https://gtfs.org/realtime/reference/#message-translation).
 	
 
 

--- a/internal/gen/api/public.pb.go
+++ b/internal/gen/api/public.pb.go
@@ -302,8 +302,8 @@ func (Stop_Type) EnumDescriptor() ([]byte, []int) {
 	return file_api_public_proto_rawDescGZIP(), []int{34, 0}
 }
 
-// Corresponds to [VehicleStopStatus](https://developers.google.com/
-// transit/gtfs-realtime/reference#enum-vehiclestopstatus).
+// Corresponds to [VehicleStopStatus](https://gtfs.org/realtime/reference/
+// #enum-vehiclestopstatus).
 type Vehicle_CurrentStatus int32
 
 const (
@@ -353,8 +353,8 @@ func (Vehicle_CurrentStatus) EnumDescriptor() ([]byte, []int) {
 	return file_api_public_proto_rawDescGZIP(), []int{37, 0}
 }
 
-// Corresponds to [CongestionLevel](https://developers.google.com/
-// transit/gtfs-realtime/reference#enum-congestionlevel).
+// Corresponds to [CongestionLevel](https://gtfs.org/realtime/reference/
+// #enum-congestionlevel).
 type Vehicle_CongestionLevel int32
 
 const (
@@ -410,8 +410,8 @@ func (Vehicle_CongestionLevel) EnumDescriptor() ([]byte, []int) {
 	return file_api_public_proto_rawDescGZIP(), []int{37, 1}
 }
 
-// Corresponds to [OccupancyStatus](https://developers.google.com/
-// transit/gtfs-realtime/reference#enum-occupancystatus).
+// Corresponds to [OccupancyStatus](https://gtfs.org/realtime/reference/
+// #enum-occupancystatus).
 type Vehicle_OccupancyStatus int32
 
 const (
@@ -606,7 +606,7 @@ func (Route_Type) EnumDescriptor() ([]byte, []int) {
 }
 
 // Cause is the same as the [cause enum in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#enum-cause),
+// specification](https://gtfs.org/realtime/feed-entities/service-alerts/#cause),
 // except `UNKNOWN_CAUSE` has value 0 instead of 1 to satisfy proto3 requirements.
 type Alert_Cause int32
 
@@ -685,7 +685,7 @@ func (Alert_Cause) EnumDescriptor() ([]byte, []int) {
 }
 
 // Effect is the same as the [effect enum in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#enum-effect),
+// specification](https://gtfs.org/realtime/feed-entities/service-alerts/#effect),
 // except `UNKNOWN_EFFECT` has value 0 instead of 1 to satisfy proto3 requirements.
 type Alert_Effect int32
 
@@ -3057,7 +3057,7 @@ func (x *ChildResources) GetHref() string {
 // The Stop resource.
 //
 // This resource corresponds to the [stop type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs/reference#stopstxt).
+// specification](https://gtfs.org/schedule/reference/#stopstxt).
 // Most of the static fields in the resource come directly from the `stops.txt` table.
 // Transiter adds some additional related fields (transfers, alerts, stop times)
 //
@@ -3106,7 +3106,7 @@ type Stop struct {
 	//
 	// These are determined using the `informed_entity` field in
 	// the [GTFS realtime alerts
-	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+	// message](https://gtfs.org/realtime/reference/#message-alert).
 	Alerts []*Alert_Reference `protobuf:"bytes,18,rep,name=alerts,proto3" json:"alerts,omitempty"`
 	// List of realtime stop times for this stop.
 	//
@@ -3303,7 +3303,7 @@ func (x *Stop) GetHeadsignRules() []*Stop_HeadsignRule {
 //
 // A stop time is an event in which a trip calls at a stop.
 // This message corresponds to the [GTFS realtime `StopTimeUpdate`
-// message](https://developers.google.com/transit/gtfs-realtime/reference#message-stoptimeupdate)
+// message](https://gtfs.org/realtime/reference/#message-stoptimeupdate)
 type StopTime struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3530,7 +3530,7 @@ func (x *Trip) GetShape() *Shape_Reference {
 // The Vehicle resource.
 //
 // This resource corresponds to the [vehicle position type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-vehicleposition).
+// specification](https://gtfs.org/realtime/reference/#message-vehicleposition).
 type Vehicle struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3699,7 +3699,7 @@ func (x *Vehicle) GetOccupancyPercentage() int32 {
 // The Route resource.
 //
 // This resource corresponds to the [route type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs/reference#routestxt).
+// specification](https://gtfs.org/schedule/reference/#routestxt).
 // Most of the fields in the resource come directly from the `routes.txt` table.
 // Transiter adds some additional related fields (agency, alerts)
 //
@@ -3744,7 +3744,7 @@ type Route struct {
 	//
 	// These are determined using the `informed_entity` field in
 	// the [GTFS realtime alerts
-	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+	// message](https://gtfs.org/realtime/reference/#message-alert).
 	Alerts []*Alert_Reference `protobuf:"bytes,15,rep,name=alerts,proto3" json:"alerts,omitempty"`
 	// An estimate of the interval of time between consecutive realtime trips, in seconds.
 	//
@@ -4028,7 +4028,7 @@ func (x *Feed) GetLastFailedUpdateMs() int64 {
 // The Agency resource.
 //
 // This resource corresponds to the [agency type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs/reference#agencytxt).
+// specification](https://gtfs.org/schedule/reference/#agencytxt).
 // Most of the fields in the resource come directly from the `agency.txt` table.
 // Transiter adds some additional related fields (alerts).
 type Agency struct {
@@ -4063,7 +4063,7 @@ type Agency struct {
 	//
 	// These are determined using the `informed_entity` field in
 	// the [GTFS realtime alerts
-	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+	// message](https://gtfs.org/realtime/reference/#message-alert).
 	Alerts []*Alert_Reference `protobuf:"bytes,12,rep,name=alerts,proto3" json:"alerts,omitempty"`
 }
 
@@ -4186,7 +4186,7 @@ func (x *Agency) GetAlerts() []*Alert_Reference {
 // The Alert resource.
 //
 // This resource corresponds to the [alert type in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+// specification](https://gtfs.org/realtime/reference/#message-alert).
 //
 // TODO; alphabetize the messages
 type Alert struct {
@@ -4195,7 +4195,7 @@ type Alert struct {
 	unknownFields protoimpl.UnknownFields
 
 	// ID of the alert. This corresponds to the [ID field in the feed entity
-	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-feedentity)
+	// message](https://gtfs.org/realtime/reference/#message-feedentity)
 	// corresponding to the alert.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Generic metadata about the alert resource.
@@ -4885,7 +4885,7 @@ func (x *Stop_Reference) GetName() string {
 
 // Message describing the arrival or departure time of a stop time.
 // This corresponds to the [GTFS realtime `StopTimeEvent`
-// message](https://developers.google.com/transit/gtfs-realtime/reference#message-stoptimeevent).
+// message](https://gtfs.org/realtime/reference/#message-stoptimeevent).
 type StopTime_EstimatedTime struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -5366,7 +5366,7 @@ func (x *Agency_Reference) GetName() string {
 
 // The active period message describes a period when an alert is active.
 // It corresponds the the [time range message in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-timerange).
+// specification](https://gtfs.org/realtime/reference/#message-timerange).
 type Alert_ActivePeriod struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -5429,8 +5429,7 @@ func (x *Alert_ActivePeriod) GetEndsAt() int64 {
 
 // The text message describes an alert header/description/URL in a specified language.
 // It corresponds the the [translation message in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-translation).
-type Alert_Text struct {
+// specification](\https://gtfs.org/realtime/reference/#message-translationruct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields

--- a/internal/gen/api/public.pb.go
+++ b/internal/gen/api/public.pb.go
@@ -302,8 +302,8 @@ func (Stop_Type) EnumDescriptor() ([]byte, []int) {
 	return file_api_public_proto_rawDescGZIP(), []int{34, 0}
 }
 
-// Corresponds to [VehicleStopStatus](https://gtfs.org/realtime/reference/
-// #enum-vehiclestopstatus).
+// Corresponds to [VehicleStopStatus](https://developers.google.com/
+// transit/gtfs-realtime/reference#enum-vehiclestopstatus).
 type Vehicle_CurrentStatus int32
 
 const (
@@ -353,8 +353,8 @@ func (Vehicle_CurrentStatus) EnumDescriptor() ([]byte, []int) {
 	return file_api_public_proto_rawDescGZIP(), []int{37, 0}
 }
 
-// Corresponds to [CongestionLevel](https://gtfs.org/realtime/reference/
-// #enum-congestionlevel).
+// Corresponds to [CongestionLevel](https://developers.google.com/
+// transit/gtfs-realtime/reference#enum-congestionlevel).
 type Vehicle_CongestionLevel int32
 
 const (
@@ -410,8 +410,8 @@ func (Vehicle_CongestionLevel) EnumDescriptor() ([]byte, []int) {
 	return file_api_public_proto_rawDescGZIP(), []int{37, 1}
 }
 
-// Corresponds to [OccupancyStatus](https://gtfs.org/realtime/reference/
-// #enum-occupancystatus).
+// Corresponds to [OccupancyStatus](https://developers.google.com/
+// transit/gtfs-realtime/reference#enum-occupancystatus).
 type Vehicle_OccupancyStatus int32
 
 const (
@@ -606,7 +606,7 @@ func (Route_Type) EnumDescriptor() ([]byte, []int) {
 }
 
 // Cause is the same as the [cause enum in the GTFS realtime
-// specification](https://gtfs.org/realtime/feed-entities/service-alerts/#cause),
+// specification](https://developers.google.com/transit/gtfs-realtime/reference#enum-cause),
 // except `UNKNOWN_CAUSE` has value 0 instead of 1 to satisfy proto3 requirements.
 type Alert_Cause int32
 
@@ -685,7 +685,7 @@ func (Alert_Cause) EnumDescriptor() ([]byte, []int) {
 }
 
 // Effect is the same as the [effect enum in the GTFS realtime
-// specification](https://gtfs.org/realtime/feed-entities/service-alerts/#effect),
+// specification](https://developers.google.com/transit/gtfs-realtime/reference#enum-effect),
 // except `UNKNOWN_EFFECT` has value 0 instead of 1 to satisfy proto3 requirements.
 type Alert_Effect int32
 
@@ -3057,7 +3057,7 @@ func (x *ChildResources) GetHref() string {
 // The Stop resource.
 //
 // This resource corresponds to the [stop type in the GTFS static
-// specification](https://gtfs.org/schedule/reference/#stopstxt).
+// specification](https://developers.google.com/transit/gtfs/reference#stopstxt).
 // Most of the static fields in the resource come directly from the `stops.txt` table.
 // Transiter adds some additional related fields (transfers, alerts, stop times)
 //
@@ -3106,7 +3106,7 @@ type Stop struct {
 	//
 	// These are determined using the `informed_entity` field in
 	// the [GTFS realtime alerts
-	// message](https://gtfs.org/realtime/reference/#message-alert).
+	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
 	Alerts []*Alert_Reference `protobuf:"bytes,18,rep,name=alerts,proto3" json:"alerts,omitempty"`
 	// List of realtime stop times for this stop.
 	//
@@ -3303,7 +3303,7 @@ func (x *Stop) GetHeadsignRules() []*Stop_HeadsignRule {
 //
 // A stop time is an event in which a trip calls at a stop.
 // This message corresponds to the [GTFS realtime `StopTimeUpdate`
-// message](https://gtfs.org/realtime/reference/#message-stoptimeupdate)
+// message](https://developers.google.com/transit/gtfs-realtime/reference#message-stoptimeupdate)
 type StopTime struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3530,7 +3530,7 @@ func (x *Trip) GetShape() *Shape_Reference {
 // The Vehicle resource.
 //
 // This resource corresponds to the [vehicle position type in the GTFS static
-// specification](https://gtfs.org/realtime/reference/#message-vehicleposition).
+// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-vehicleposition).
 type Vehicle struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3699,7 +3699,7 @@ func (x *Vehicle) GetOccupancyPercentage() int32 {
 // The Route resource.
 //
 // This resource corresponds to the [route type in the GTFS static
-// specification](https://gtfs.org/schedule/reference/#routestxt).
+// specification](https://developers.google.com/transit/gtfs/reference#routestxt).
 // Most of the fields in the resource come directly from the `routes.txt` table.
 // Transiter adds some additional related fields (agency, alerts)
 //
@@ -3744,7 +3744,7 @@ type Route struct {
 	//
 	// These are determined using the `informed_entity` field in
 	// the [GTFS realtime alerts
-	// message](https://gtfs.org/realtime/reference/#message-alert).
+	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
 	Alerts []*Alert_Reference `protobuf:"bytes,15,rep,name=alerts,proto3" json:"alerts,omitempty"`
 	// An estimate of the interval of time between consecutive realtime trips, in seconds.
 	//
@@ -4028,7 +4028,7 @@ func (x *Feed) GetLastFailedUpdateMs() int64 {
 // The Agency resource.
 //
 // This resource corresponds to the [agency type in the GTFS static
-// specification](https://gtfs.org/schedule/reference/#agencytxt).
+// specification](https://developers.google.com/transit/gtfs/reference#agencytxt).
 // Most of the fields in the resource come directly from the `agency.txt` table.
 // Transiter adds some additional related fields (alerts).
 type Agency struct {
@@ -4063,7 +4063,7 @@ type Agency struct {
 	//
 	// These are determined using the `informed_entity` field in
 	// the [GTFS realtime alerts
-	// message](https://gtfs.org/realtime/reference/#message-alert).
+	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
 	Alerts []*Alert_Reference `protobuf:"bytes,12,rep,name=alerts,proto3" json:"alerts,omitempty"`
 }
 
@@ -4186,7 +4186,7 @@ func (x *Agency) GetAlerts() []*Alert_Reference {
 // The Alert resource.
 //
 // This resource corresponds to the [alert type in the GTFS realtime
-// specification](https://gtfs.org/realtime/reference/#message-alert).
+// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
 //
 // TODO; alphabetize the messages
 type Alert struct {
@@ -4195,7 +4195,7 @@ type Alert struct {
 	unknownFields protoimpl.UnknownFields
 
 	// ID of the alert. This corresponds to the [ID field in the feed entity
-	// message](https://gtfs.org/realtime/reference/#message-feedentity)
+	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-feedentity)
 	// corresponding to the alert.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Generic metadata about the alert resource.
@@ -4885,7 +4885,7 @@ func (x *Stop_Reference) GetName() string {
 
 // Message describing the arrival or departure time of a stop time.
 // This corresponds to the [GTFS realtime `StopTimeEvent`
-// message](https://gtfs.org/realtime/reference/#message-stoptimeevent).
+// message](https://developers.google.com/transit/gtfs-realtime/reference#message-stoptimeevent).
 type StopTime_EstimatedTime struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -5366,7 +5366,7 @@ func (x *Agency_Reference) GetName() string {
 
 // The active period message describes a period when an alert is active.
 // It corresponds the the [time range message in the GTFS realtime
-// specification](https://gtfs.org/realtime/reference/#message-timerange).
+// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-timerange).
 type Alert_ActivePeriod struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -5429,7 +5429,8 @@ func (x *Alert_ActivePeriod) GetEndsAt() int64 {
 
 // The text message describes an alert header/description/URL in a specified language.
 // It corresponds the the [translation message in the GTFS realtime
-// specification](\https://gtfs.org/realtime/reference/#message-translationruct {
+// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-translation).
+type Alert_Text struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields

--- a/internal/gen/api/public.pb.go
+++ b/internal/gen/api/public.pb.go
@@ -6,15 +6,15 @@
 //
 //```
 //System
-// |- Agency
-// |- Alert
-// |- Feed
-// |- Route
-// |   |- Trip
-// |       |- Vehicle with no ID
-// |- Stop
-// |- Transfer
-// |- Vehicle with ID
+//|- Agency
+//|- Alert
+//|- Feed
+//|- Route
+//|   |- Trip
+//|       |- Vehicle with no ID
+//|- Stop
+//|- Transfer
+//|- Vehicle with ID
 //```
 //
 //For each resource there is a proto message type, a list endpoint, and a get endpoints.
@@ -34,10 +34,10 @@
 //Each stop has a list of service maps, each of which contains a set of routes.
 //In these situations the resource message contains a _reference_ to the other resource.
 //The [Route](#route) message contains an agency reference, in the form of an [Agency.Reference](#agencyreference)
-// message.
+//message.
 //These reference messages contain at least enough information to uniquely identify the resource.
 //However they also contain additional information that is considered generally useful;
-// thus, the [Stop.Reference](#stopreference) message contains the stop's name.
+//thus, the [Stop.Reference](#stopreference) message contains the stop's name.
 //What counts as "considered generally" is obviously very subjective and open to change.
 //
 //The following table summarizes all of the resources and their types.
@@ -302,8 +302,8 @@ func (Stop_Type) EnumDescriptor() ([]byte, []int) {
 	return file_api_public_proto_rawDescGZIP(), []int{34, 0}
 }
 
-// Corresponds to [VehicleStopStatus](https://developers.google.com/
-// transit/gtfs-realtime/reference#enum-vehiclestopstatus).
+// Corresponds to [VehicleStopStatus](https://gtfs.org/realtime/reference/
+// #enum-vehiclestopstatus).
 type Vehicle_CurrentStatus int32
 
 const (
@@ -353,8 +353,8 @@ func (Vehicle_CurrentStatus) EnumDescriptor() ([]byte, []int) {
 	return file_api_public_proto_rawDescGZIP(), []int{37, 0}
 }
 
-// Corresponds to [CongestionLevel](https://developers.google.com/
-// transit/gtfs-realtime/reference#enum-congestionlevel).
+// Corresponds to [CongestionLevel](https://gtfs.org/realtime/reference/
+// #enum-congestionlevel).
 type Vehicle_CongestionLevel int32
 
 const (
@@ -410,8 +410,8 @@ func (Vehicle_CongestionLevel) EnumDescriptor() ([]byte, []int) {
 	return file_api_public_proto_rawDescGZIP(), []int{37, 1}
 }
 
-// Corresponds to [OccupancyStatus](https://developers.google.com/
-// transit/gtfs-realtime/reference#enum-occupancystatus).
+// Corresponds to [OccupancyStatus](https://gtfs.org/realtime/reference/
+// #enum-occupancystatus).
 type Vehicle_OccupancyStatus int32
 
 const (
@@ -606,7 +606,7 @@ func (Route_Type) EnumDescriptor() ([]byte, []int) {
 }
 
 // Cause is the same as the [cause enum in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#enum-cause),
+// specification](https://gtfs.org/realtime/feed-entities/service-alerts/#cause),
 // except `UNKNOWN_CAUSE` has value 0 instead of 1 to satisfy proto3 requirements.
 type Alert_Cause int32
 
@@ -685,7 +685,7 @@ func (Alert_Cause) EnumDescriptor() ([]byte, []int) {
 }
 
 // Effect is the same as the [effect enum in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#enum-effect),
+// specification](https://gtfs.org/realtime/feed-entities/service-alerts/#effect),
 // except `UNKNOWN_EFFECT` has value 0 instead of 1 to satisfy proto3 requirements.
 type Alert_Effect int32
 
@@ -3057,7 +3057,7 @@ func (x *ChildResources) GetHref() string {
 // The Stop resource.
 //
 // This resource corresponds to the [stop type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs/reference#stopstxt).
+// specification](https://gtfs.org/schedule/reference/#stopstxt).
 // Most of the static fields in the resource come directly from the `stops.txt` table.
 // Transiter adds some additional related fields (transfers, alerts, stop times)
 //
@@ -3106,7 +3106,7 @@ type Stop struct {
 	//
 	// These are determined using the `informed_entity` field in
 	// the [GTFS realtime alerts
-	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+	// message](https://gtfs.org/realtime/reference/#message-alert).
 	Alerts []*Alert_Reference `protobuf:"bytes,18,rep,name=alerts,proto3" json:"alerts,omitempty"`
 	// List of realtime stop times for this stop.
 	//
@@ -3303,7 +3303,7 @@ func (x *Stop) GetHeadsignRules() []*Stop_HeadsignRule {
 //
 // A stop time is an event in which a trip calls at a stop.
 // This message corresponds to the [GTFS realtime `StopTimeUpdate`
-// message](https://developers.google.com/transit/gtfs-realtime/reference#message-stoptimeupdate)
+// message](https://gtfs.org/realtime/reference/#message-stoptimeupdate)
 type StopTime struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3530,7 +3530,7 @@ func (x *Trip) GetShape() *Shape_Reference {
 // The Vehicle resource.
 //
 // This resource corresponds to the [vehicle position type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-vehicleposition).
+// specification](https://gtfs.org/realtime/reference/#message-vehicleposition).
 type Vehicle struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3699,7 +3699,7 @@ func (x *Vehicle) GetOccupancyPercentage() int32 {
 // The Route resource.
 //
 // This resource corresponds to the [route type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs/reference#routestxt).
+// specification](https://gtfs.org/schedule/reference/#routestxt).
 // Most of the fields in the resource come directly from the `routes.txt` table.
 // Transiter adds some additional related fields (agency, alerts)
 //
@@ -3744,7 +3744,7 @@ type Route struct {
 	//
 	// These are determined using the `informed_entity` field in
 	// the [GTFS realtime alerts
-	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+	// message](https://gtfs.org/realtime/feed-entities/service-alerts/#service-alerts).
 	Alerts []*Alert_Reference `protobuf:"bytes,15,rep,name=alerts,proto3" json:"alerts,omitempty"`
 	// An estimate of the interval of time between consecutive realtime trips, in seconds.
 	//
@@ -4028,7 +4028,7 @@ func (x *Feed) GetLastFailedUpdateMs() int64 {
 // The Agency resource.
 //
 // This resource corresponds to the [agency type in the GTFS static
-// specification](https://developers.google.com/transit/gtfs/reference#agencytxt).
+// specification](https://gtfs.org/schedule/reference/#agencytxt).
 // Most of the fields in the resource come directly from the `agency.txt` table.
 // Transiter adds some additional related fields (alerts).
 type Agency struct {
@@ -4063,7 +4063,7 @@ type Agency struct {
 	//
 	// These are determined using the `informed_entity` field in
 	// the [GTFS realtime alerts
-	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+	// message](https://gtfs.org/realtime/reference/#message-alert).
 	Alerts []*Alert_Reference `protobuf:"bytes,12,rep,name=alerts,proto3" json:"alerts,omitempty"`
 }
 
@@ -4186,7 +4186,7 @@ func (x *Agency) GetAlerts() []*Alert_Reference {
 // The Alert resource.
 //
 // This resource corresponds to the [alert type in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-alert).
+// specification](https://gtfs.org/realtime/reference/#message-alert).
 //
 // TODO; alphabetize the messages
 type Alert struct {
@@ -4195,7 +4195,7 @@ type Alert struct {
 	unknownFields protoimpl.UnknownFields
 
 	// ID of the alert. This corresponds to the [ID field in the feed entity
-	// message](https://developers.google.com/transit/gtfs-realtime/reference#message-feedentity)
+	// message](https://gtfs.org/realtime/reference/#message-feedentity)
 	// corresponding to the alert.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Generic metadata about the alert resource.
@@ -4885,7 +4885,7 @@ func (x *Stop_Reference) GetName() string {
 
 // Message describing the arrival or departure time of a stop time.
 // This corresponds to the [GTFS realtime `StopTimeEvent`
-// message](https://developers.google.com/transit/gtfs-realtime/reference#message-stoptimeevent).
+// message](https://gtfs.org/realtime/reference/#message-stoptimeevent).
 type StopTime_EstimatedTime struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -5366,7 +5366,7 @@ func (x *Agency_Reference) GetName() string {
 
 // The active period message describes a period when an alert is active.
 // It corresponds the the [time range message in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-timerange).
+// specification](https://gtfs.org/realtime/reference/#message-timerange).
 type Alert_ActivePeriod struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -5429,7 +5429,7 @@ func (x *Alert_ActivePeriod) GetEndsAt() int64 {
 
 // The text message describes an alert header/description/URL in a specified language.
 // It corresponds the the [translation message in the GTFS realtime
-// specification](https://developers.google.com/transit/gtfs-realtime/reference#message-translation).
+// specification](https://gtfs.org/realtime/reference/#message-translation).
 type Alert_Text struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache


### PR DESCRIPTION
These changes update the GTFS static specification from the deprecated documentation at https://developers.google.com/transit/gtfs/reference/ to the current documentation at https://gtfs.org/reference/static/.

See the image below for the deprecated reference page: https://developers.google.com/transit/gtfs/reference/ 
![image](https://github.com/jamespfennell/transiter/assets/73621296/1ca395d0-cd90-4ae6-9740-320c8ab3f35f)
