### PR TITLE
Provide stop time headsign from static GTFS data when possible

### DIFF
--- a/internal/public/endpoints/stop.go
+++ b/internal/public/endpoints/stop.go
@@ -422,11 +422,18 @@ func buildStopPkToApiStopsTimes(
 	}
 	for i := range data.stopTimes {
 		stopTime := &data.stopTimes[i]
+		headsign := stopTime.Headsign
+		// If the headsign is not calculated from realtime trip data,
+		// try to fall back to the scheduled trip headsign
+		if !headsign.Valid {
+			headsign = stopTime.ScheduledTripHeadsign
+		}
+
 		apiStopTime := &api.StopTime{
 			StopSequence: stopTime.StopSequence,
 			Track:        convert.SQLNullString(stopTime.Track),
 			Future:       !stopTime.Past,
-			Headsign:     convert.SQLNullString(stopTime.Headsign),
+			Headsign:     convert.SQLNullString(headsign),
 			Arrival:      buildEstimatedTime(stopTime.ArrivalTime, stopTime.ArrivalDelay, stopTime.ArrivalUncertainty),
 			Departure:    buildEstimatedTime(stopTime.DepartureTime, stopTime.DepartureDelay, stopTime.DepartureUncertainty),
 			Trip: r.Reference.Trip(

--- a/tests/endtoend/gtfs_utils.py
+++ b/tests/endtoend/gtfs_utils.py
@@ -1,0 +1,38 @@
+from . import gtfs_realtime_pb2 as gtfs
+
+def build_gtfs_rt_trip_update_message(
+    trip_id,
+    route_id,
+    current_time,
+    stop_id_to_time,
+    use_stop_sequences,
+    stop_sequence_offset=0,
+    feed_id="1",
+):
+    return gtfs.FeedMessage(
+        header=gtfs.FeedHeader(gtfs_realtime_version="2.0", timestamp=current_time),
+        entity=[
+            gtfs.FeedEntity(
+                id=feed_id,
+                trip_update=gtfs.TripUpdate(
+                    trip=gtfs.TripDescriptor(
+                        trip_id=trip_id, route_id=route_id, direction_id=True
+                    ),
+                    stop_time_update=[
+                        gtfs.TripUpdate.StopTimeUpdate(
+                            arrival=gtfs.TripUpdate.StopTimeEvent(time=time),
+                            departure=gtfs.TripUpdate.StopTimeEvent(time=time + 15),
+                            stop_id=stop_id,
+                            stop_sequence=(
+                                stop_sequence_offset + stop_sequence if use_stop_sequences else None
+                            ),
+                        )
+                        for stop_sequence, (stop_id, time) in enumerate(
+                            stop_id_to_time.items()
+                        )
+                        if time >= current_time
+                    ],
+                ),
+            )
+        ],
+    )


### PR DESCRIPTION
This change returns the headsign from GTFS static data when applicable/possible for a stop's stop times. For the NYC subway system, this has not been needed due the custom headsign calculation logic implemented for it. However, for other systems such as the NYC bus, the headsign is currently always undefined.

With this change, the logic for returning the headsign within the context of the `/stop` and `/stop/{stop_id}` endpoints is as follows:

1. First try to use the real-time-calculated headsign if it is assigned in the `trip` table.
2. Next, try to use the headsign of the corresponding`stop`/`stop_sequence` entry for the trip in the `scheduled_trip_stop_time` table. This is for cases where a headsign changes depending on the stop/stop sequence and should take precedence over the headsign entry in the `scheduled_trip` table.
3. Finally, try to use the headsign in the `scheduled_trip` table.

An end-to-end test has also been added to test the new behavior of the static data integration.

Similar logic could be used to also return headsigns for stop times returned from the `/trip` endpoint in a subsequent change if there is a need for it.