### PR TITLE
[Accessibility] Handle wheelchair_boarding inheritance in stops

### DIFF
--- a/db/queries/stop_queries.sql
+++ b/db/queries/stop_queries.sql
@@ -165,3 +165,8 @@ WHERE
         NOT sqlc.arg(filter_by_stop_id)::bool
         OR id = ANY(sqlc.arg(stop_ids)::text[])
     );
+
+-- name: UpdateStopWheelchairBoarding :exec
+UPDATE stop
+SET wheelchair_boarding = sqlc.arg(wheelchair_boarding)
+WHERE pk = sqlc.arg(pk);

--- a/internal/gen/db/querier.go
+++ b/internal/gen/db/querier.go
@@ -131,6 +131,7 @@ type Querier interface {
 	UpdateRoute(ctx context.Context, arg UpdateRouteParams) error
 	UpdateServiceMapConfig(ctx context.Context, arg UpdateServiceMapConfigParams) error
 	UpdateStop(ctx context.Context, arg UpdateStopParams) error
+	UpdateStopWheelchairBoarding(ctx context.Context, arg UpdateStopWheelchairBoardingParams) error
 	UpdateStop_Parent(ctx context.Context, arg UpdateStop_ParentParams) error
 	UpdateSystem(ctx context.Context, arg UpdateSystemParams) error
 	UpdateSystemStatus(ctx context.Context, arg UpdateSystemStatusParams) error

--- a/internal/gen/db/stop_queries.sql.go
+++ b/internal/gen/db/stop_queries.sql.go
@@ -619,6 +619,22 @@ func (q *Queries) UpdateStop(ctx context.Context, arg UpdateStopParams) error {
 	return err
 }
 
+const updateStopWheelchairBoarding = `-- name: UpdateStopWheelchairBoarding :exec
+UPDATE stop
+SET wheelchair_boarding = $1
+WHERE pk = $2
+`
+
+type UpdateStopWheelchairBoardingParams struct {
+	WheelchairBoarding pgtype.Bool
+	Pk                 int64
+}
+
+func (q *Queries) UpdateStopWheelchairBoarding(ctx context.Context, arg UpdateStopWheelchairBoardingParams) error {
+	_, err := q.db.Exec(ctx, updateStopWheelchairBoarding, arg.WheelchairBoarding, arg.Pk)
+	return err
+}
+
 const updateStop_Parent = `-- name: UpdateStop_Parent :exec
 UPDATE stop SET
     parent_stop_pk = $1


### PR DESCRIPTION
This change properly handles the case where a child stop/platform inherits it's parent station's `wheelchair_boarding` value when not specified directly.