### PR TITLE
Simplify update stop conditional

### DIFF
--- a/db/queries/stop_queries.sql
+++ b/db/queries/stop_queries.sql
@@ -10,7 +10,6 @@ VALUES
      sqlc.arg(timezone), sqlc.arg(type), sqlc.arg(wheelchair_boarding), sqlc.arg(zone_id))
 RETURNING pk;
 
--- case when done = false then o2.done_ts else o.done_ts end
 -- name: UpdateStop :exec
 UPDATE stop SET
     feed_pk = sqlc.arg(feed_pk),

--- a/db/queries/stop_queries.sql
+++ b/db/queries/stop_queries.sql
@@ -21,23 +21,7 @@ UPDATE stop SET
     platform_code = sqlc.arg(platform_code),
     timezone = sqlc.arg(timezone),
     type = sqlc.arg(type),
-    wheelchair_boarding = sqlc.arg(wheelchair_boarding),
-    zone_id = sqlc.arg(zone_id),
-    parent_stop_pk = NULL
-WHERE
-    pk = sqlc.arg(pk);
-
--- name: UpdateStopWithoutWheelchairBoarding :exec
-UPDATE stop SET
-    feed_pk = sqlc.arg(feed_pk),
-    name = sqlc.arg(name),
-    location = sqlc.arg(location)::geography,
-    url = sqlc.arg(url),
-    code = sqlc.arg(code),
-    description = sqlc.arg(description),
-    platform_code = sqlc.arg(platform_code),
-    timezone = sqlc.arg(timezone),
-    type = sqlc.arg(type),
+    wheelchair_boarding = IF(sqlc.arg(update_wheelchair_boarding), sqlc.arg(wheelchair_boarding), wheelchair_boarding),
     zone_id = sqlc.arg(zone_id),
     parent_stop_pk = NULL
 WHERE

--- a/db/queries/stop_queries.sql
+++ b/db/queries/stop_queries.sql
@@ -10,6 +10,7 @@ VALUES
      sqlc.arg(timezone), sqlc.arg(type), sqlc.arg(wheelchair_boarding), sqlc.arg(zone_id))
 RETURNING pk;
 
+-- case when done = false then o2.done_ts else o.done_ts end
 -- name: UpdateStop :exec
 UPDATE stop SET
     feed_pk = sqlc.arg(feed_pk),
@@ -21,7 +22,7 @@ UPDATE stop SET
     platform_code = sqlc.arg(platform_code),
     timezone = sqlc.arg(timezone),
     type = sqlc.arg(type),
-    wheelchair_boarding = IF(sqlc.arg(update_wheelchair_boarding), sqlc.arg(wheelchair_boarding), wheelchair_boarding),
+    wheelchair_boarding = CASE WHEN sqlc.arg(update_wheelchair_boarding)::boolean THEN sqlc.arg(wheelchair_boarding) ELSE wheelchair_boarding END,
     zone_id = sqlc.arg(zone_id),
     parent_stop_pk = NULL
 WHERE

--- a/internal/gen/db/querier.go
+++ b/internal/gen/db/querier.go
@@ -132,7 +132,6 @@ type Querier interface {
 	UpdateFeed(ctx context.Context, arg UpdateFeedParams) error
 	UpdateRoute(ctx context.Context, arg UpdateRouteParams) error
 	UpdateServiceMapConfig(ctx context.Context, arg UpdateServiceMapConfigParams) error
-	// case when done = false then o2.done_ts else o.done_ts end
 	UpdateStop(ctx context.Context, arg UpdateStopParams) error
 	UpdateStop_Parent(ctx context.Context, arg UpdateStop_ParentParams) error
 	UpdateSystem(ctx context.Context, arg UpdateSystemParams) error

--- a/internal/gen/db/querier.go
+++ b/internal/gen/db/querier.go
@@ -133,7 +133,6 @@ type Querier interface {
 	UpdateRoute(ctx context.Context, arg UpdateRouteParams) error
 	UpdateServiceMapConfig(ctx context.Context, arg UpdateServiceMapConfigParams) error
 	UpdateStop(ctx context.Context, arg UpdateStopParams) error
-	UpdateStopWithoutWheelchairBoarding(ctx context.Context, arg UpdateStopWithoutWheelchairBoardingParams) error
 	UpdateStop_Parent(ctx context.Context, arg UpdateStop_ParentParams) error
 	UpdateSystem(ctx context.Context, arg UpdateSystemParams) error
 	UpdateSystemStatus(ctx context.Context, arg UpdateSystemStatusParams) error

--- a/internal/gen/db/querier.go
+++ b/internal/gen/db/querier.go
@@ -132,6 +132,7 @@ type Querier interface {
 	UpdateFeed(ctx context.Context, arg UpdateFeedParams) error
 	UpdateRoute(ctx context.Context, arg UpdateRouteParams) error
 	UpdateServiceMapConfig(ctx context.Context, arg UpdateServiceMapConfigParams) error
+	// case when done = false then o2.done_ts else o.done_ts end
 	UpdateStop(ctx context.Context, arg UpdateStopParams) error
 	UpdateStop_Parent(ctx context.Context, arg UpdateStop_ParentParams) error
 	UpdateSystem(ctx context.Context, arg UpdateSystemParams) error

--- a/internal/gen/db/stop_queries.sql.go
+++ b/internal/gen/db/stop_queries.sql.go
@@ -590,26 +590,27 @@ UPDATE stop SET
     platform_code = $7,
     timezone = $8,
     type = $9,
-    wheelchair_boarding = $10,
-    zone_id = $11,
+    wheelchair_boarding = IF($10, $11, wheelchair_boarding),
+    zone_id = $12,
     parent_stop_pk = NULL
 WHERE
-    pk = $12
+    pk = $13
 `
 
 type UpdateStopParams struct {
-	FeedPk             int64
-	Name               pgtype.Text
-	Location           types.Geography
-	Url                pgtype.Text
-	Code               pgtype.Text
-	Description        pgtype.Text
-	PlatformCode       pgtype.Text
-	Timezone           pgtype.Text
-	Type               string
-	WheelchairBoarding pgtype.Bool
-	ZoneID             pgtype.Text
-	Pk                 int64
+	FeedPk                   int64
+	Name                     pgtype.Text
+	Location                 types.Geography
+	Url                      pgtype.Text
+	Code                     pgtype.Text
+	Description              pgtype.Text
+	PlatformCode             pgtype.Text
+	Timezone                 pgtype.Text
+	Type                     string
+	UpdateWheelchairBoarding interface{}
+	WheelchairBoarding       interface{}
+	ZoneID                   pgtype.Text
+	Pk                       int64
 }
 
 func (q *Queries) UpdateStop(ctx context.Context, arg UpdateStopParams) error {
@@ -623,55 +624,8 @@ func (q *Queries) UpdateStop(ctx context.Context, arg UpdateStopParams) error {
 		arg.PlatformCode,
 		arg.Timezone,
 		arg.Type,
+		arg.UpdateWheelchairBoarding,
 		arg.WheelchairBoarding,
-		arg.ZoneID,
-		arg.Pk,
-	)
-	return err
-}
-
-const updateStopWithoutWheelchairBoarding = `-- name: UpdateStopWithoutWheelchairBoarding :exec
-UPDATE stop SET
-    feed_pk = $1,
-    name = $2,
-    location = $3::geography,
-    url = $4,
-    code = $5,
-    description = $6,
-    platform_code = $7,
-    timezone = $8,
-    type = $9,
-    zone_id = $10,
-    parent_stop_pk = NULL
-WHERE
-    pk = $11
-`
-
-type UpdateStopWithoutWheelchairBoardingParams struct {
-	FeedPk       int64
-	Name         pgtype.Text
-	Location     types.Geography
-	Url          pgtype.Text
-	Code         pgtype.Text
-	Description  pgtype.Text
-	PlatformCode pgtype.Text
-	Timezone     pgtype.Text
-	Type         string
-	ZoneID       pgtype.Text
-	Pk           int64
-}
-
-func (q *Queries) UpdateStopWithoutWheelchairBoarding(ctx context.Context, arg UpdateStopWithoutWheelchairBoardingParams) error {
-	_, err := q.db.Exec(ctx, updateStopWithoutWheelchairBoarding,
-		arg.FeedPk,
-		arg.Name,
-		arg.Location,
-		arg.Url,
-		arg.Code,
-		arg.Description,
-		arg.PlatformCode,
-		arg.Timezone,
-		arg.Type,
 		arg.ZoneID,
 		arg.Pk,
 	)

--- a/internal/gen/db/stop_queries.sql.go
+++ b/internal/gen/db/stop_queries.sql.go
@@ -590,7 +590,7 @@ UPDATE stop SET
     platform_code = $7,
     timezone = $8,
     type = $9,
-    wheelchair_boarding = IF($10, $11, wheelchair_boarding),
+    wheelchair_boarding = CASE WHEN $10::boolean THEN $11 ELSE wheelchair_boarding END,
     zone_id = $12,
     parent_stop_pk = NULL
 WHERE
@@ -607,12 +607,13 @@ type UpdateStopParams struct {
 	PlatformCode             pgtype.Text
 	Timezone                 pgtype.Text
 	Type                     string
-	UpdateWheelchairBoarding interface{}
-	WheelchairBoarding       interface{}
+	UpdateWheelchairBoarding bool
+	WheelchairBoarding       pgtype.Bool
 	ZoneID                   pgtype.Text
 	Pk                       int64
 }
 
+// case when done = false then o2.done_ts else o.done_ts end
 func (q *Queries) UpdateStop(ctx context.Context, arg UpdateStopParams) error {
 	_, err := q.db.Exec(ctx, updateStop,
 		arg.FeedPk,

--- a/internal/gen/db/stop_queries.sql.go
+++ b/internal/gen/db/stop_queries.sql.go
@@ -613,7 +613,6 @@ type UpdateStopParams struct {
 	Pk                       int64
 }
 
-// case when done = false then o2.done_ts else o.done_ts end
 func (q *Queries) UpdateStop(ctx context.Context, arg UpdateStopParams) error {
 	_, err := q.db.Exec(ctx, updateStop,
 		arg.FeedPk,

--- a/internal/update/static/static.go
+++ b/internal/update/static/static.go
@@ -180,36 +180,21 @@ func updateStops(ctx context.Context, updateCtx common.UpdateContext, stops []gt
 	for _, stop := range stops {
 		pk, ok := oldIDToPk[stop.Id]
 		if ok {
-			if useAccessibilityInfo {
-				err = updateCtx.Querier.UpdateStop(ctx, db.UpdateStopParams{
-					Pk:                 pk,
-					FeedPk:             updateCtx.FeedPk,
-					Name:               convert.NullIfEmptyString(stop.Name),
-					Type:               stop.Type.String(),
-					Location:           convert.Gps(stop.Longitude, stop.Latitude),
-					Url:                convert.NullIfEmptyString(stop.Url),
-					Code:               convert.NullIfEmptyString(stop.Code),
-					Description:        convert.NullIfEmptyString(stop.Description),
-					PlatformCode:       convert.NullIfEmptyString(stop.PlatformCode),
-					Timezone:           convert.NullIfEmptyString(stop.Timezone),
-					WheelchairBoarding: convert.WheelchairAccessible(stop.WheelchairBoarding),
-					ZoneID:             convert.NullIfEmptyString(stop.ZoneId),
-				})
-			} else {
-				err = updateCtx.Querier.UpdateStopWithoutWheelchairBoarding(ctx, db.UpdateStopWithoutWheelchairBoardingParams{
-					Pk:           pk,
-					FeedPk:       updateCtx.FeedPk,
-					Name:         convert.NullIfEmptyString(stop.Name),
-					Type:         stop.Type.String(),
-					Location:     convert.Gps(stop.Longitude, stop.Latitude),
-					Url:          convert.NullIfEmptyString(stop.Url),
-					Code:         convert.NullIfEmptyString(stop.Code),
-					Description:  convert.NullIfEmptyString(stop.Description),
-					PlatformCode: convert.NullIfEmptyString(stop.PlatformCode),
-					Timezone:     convert.NullIfEmptyString(stop.Timezone),
-					ZoneID:       convert.NullIfEmptyString(stop.ZoneId),
-				})
-			}
+			err = updateCtx.Querier.UpdateStop(ctx, db.UpdateStopParams{
+				Pk:                       pk,
+				FeedPk:                   updateCtx.FeedPk,
+				Name:                     convert.NullIfEmptyString(stop.Name),
+				Type:                     stop.Type.String(),
+				Location:                 convert.Gps(stop.Longitude, stop.Latitude),
+				Url:                      convert.NullIfEmptyString(stop.Url),
+				Code:                     convert.NullIfEmptyString(stop.Code),
+				Description:              convert.NullIfEmptyString(stop.Description),
+				PlatformCode:             convert.NullIfEmptyString(stop.PlatformCode),
+				Timezone:                 convert.NullIfEmptyString(stop.Timezone),
+				UpdateWheelchairBoarding: useAccessibilityInfo,
+				WheelchairBoarding:       convert.WheelchairAccessible(stop.WheelchairBoarding),
+				ZoneID:                   convert.NullIfEmptyString(stop.ZoneId),
+			})
 		} else {
 			pk, err = updateCtx.Querier.InsertStop(ctx, db.InsertStopParams{
 				ID:                 stop.Id,


### PR DESCRIPTION
Instead of having two queries based on whether to update the wheelchair boarding column, we can have one query that uses a second boolean parameter to decide the behavior.

In general this is my "hack" for getting around the lack of composibility in `sqlc`: adding a boolean parameter to switch the behavior.
