### PR TITLE
Relax FK constraint for trip_pk on vehicles table to prevent deadlocks

### DIFF
--- a/db/queries/trip_queries.sql
+++ b/db/queries/trip_queries.sql
@@ -137,5 +137,4 @@ SELECT trip.id, trip.pk
 FROM trip
     INNER JOIN feed ON trip.feed_pk = feed.pk
 WHERE trip.id = ANY(sqlc.arg(trip_ids)::text[])
-    AND feed.system_pk = sqlc.arg(system_pk)
-FOR UPDATE;
+    AND feed.system_pk = sqlc.arg(system_pk);

--- a/db/schema/012_relax_vehicle_trip_constaint.sql
+++ b/db/schema/012_relax_vehicle_trip_constaint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE vehicle DROP CONSTRAINT IF EXISTS fk_vehicle_trip_pk;

--- a/internal/gen/db/trip_queries.sql.go
+++ b/internal/gen/db/trip_queries.sql.go
@@ -424,7 +424,6 @@ FROM trip
     INNER JOIN feed ON trip.feed_pk = feed.pk
 WHERE trip.id = ANY($1::text[])
     AND feed.system_pk = $2
-FOR UPDATE
 `
 
 type MapTripIDToPkInSystemParams struct {

--- a/internal/update/realtime/realtime.go
+++ b/internal/update/realtime/realtime.go
@@ -760,8 +760,6 @@ func updateVehicles(ctx context.Context, updateCtx common.UpdateContext, vehicle
 		}
 	}
 
-	// This statement also acquires a lock on the rows in the trip table associated
-	// with vehicles being inserted/updated.
 	tripIDToPk, err := dbwrappers.MapTripIDToPkInSystem(ctx, updateCtx.Querier, updateCtx.SystemPk, tripIDs)
 	if err != nil {
 		return err
@@ -772,9 +770,6 @@ func updateVehicles(ctx context.Context, updateCtx common.UpdateContext, vehicle
 		return err
 	}
 
-	// This statement does not currently lock the rows in the stop table associated
-	// with vehicles being inserted/updated. However, changes to the stop table should
-	// be rare, so conflicts should not be a major issue.
 	stopIDToPk, err := dbwrappers.MapStopIDToPkInSystem(ctx, updateCtx.Querier, updateCtx.SystemPk, stopIDs)
 	if err != nil {
 		return err
@@ -865,8 +860,11 @@ func updateVehicles(ctx context.Context, updateCtx common.UpdateContext, vehicle
 
 	for _, param := range insertVehicleParams {
 		err = updateCtx.Querier.InsertVehicle(ctx, param)
+		if err != nil {
+			return err
+		}
 	}
-	return err
+	return nil
 }
 
 func ptr[T any](t T) *T {


### PR DESCRIPTION
## Problem

Currently, there is contention between the `trip` and `vehicle` table when `trips` are removed between them being associated with a `vehicle` and the `vehicle` being inserted. The previous workaround was to acquire a lock on all `trip` rows that are associated with vehicles in the update.

However, this causes deadlocks when both trip updates and vehicle updates run concurrently. This issue is exacerbated by slow SQL performance (which is when I first noticed this issue due to my DB cluster being overloaded). In some cases, this can cause the trip and vehicle feeds to be significantly delayed (especially for the NYC bus feeds).

## Workaround tried

I tried to check for the trip's existence right before executing the insert (instead of locking the trip rows all at once), but this also resulted in deadlocks and still some FK constraint violations:

```sql
WITH trip_check AS (
    SELECT 1
    FROM trip
    WHERE trip.pk = sqlc.arg(trip_pk)
)
INSERT INTO vehicle
    (id, system_pk, trip_pk, label, license_plate, current_status, location, bearing, odometer, speed, congestion_level, updated_at, current_stop_pk, current_stop_sequence, occupancy_status, feed_pk, occupancy_percentage)
SELECT
    sqlc.arg(id), sqlc.arg(system_pk), sqlc.arg(trip_pk), sqlc.arg(label), sqlc.arg(license_plate), sqlc.arg(current_status), sqlc.arg(location), sqlc.arg(bearing), sqlc.arg(odometer), sqlc.arg(speed), sqlc.arg(congestion_level), sqlc.arg(updated_at), sqlc.arg(current_stop_pk), sqlc.arg(current_stop_sequence), sqlc.arg(occupancy_status), sqlc.arg(feed_pk), sqlc.arg(occupancy_percentage)
FROM trip_check;
```

## Solution

The best solution I've found is to simply drop the FK constraint on the `trip_pk` field in the `vehicle` table. This allows for the inserts to always go through at the cost of having the DB state in an inconsistent state. However, as the `trip_pk` field is already nullable, there is already implicitly a loose associated between a vehicle and a trip and joins between the 2 should continue to work the same as before.

In my testing, this solution has so far completely solved the deadlock issue and has improved the latency of both trip and vehicle updates for the NYC bus system. I will continue to monitor my deployment of this solution to see if this continues to be the case.

@jamespfennell if you have any other ideas, please let me know. I am certainly not thrilled with my current workaround, but I am also not sure if there is a more elegant solution that both avoids deadlocks and performance pitfalls.