### PR TITLE
add resource + system to root API objects

### DIFF
--- a/internal/public/endpoints/agency.go
+++ b/internal/public/endpoints/agency.go
@@ -64,6 +64,8 @@ func buildApiAgencies(ctx context.Context, r *Context, systemID string, dbAgenci
 		}
 		apiAgency := &api.Agency{
 			Id:       dbAgency.ID,
+			Resource: r.Reference.Agency(dbAgency.ID, systemID, dbAgency.Name).Resource,
+			System:   r.Reference.System(systemID),
 			Name:     dbAgency.Name,
 			Url:      dbAgency.Url,
 			Timezone: dbAgency.Timezone,

--- a/internal/public/endpoints/alert.go
+++ b/internal/public/endpoints/alert.go
@@ -27,7 +27,7 @@ func ListAlerts(ctx context.Context, r *Context, req *api.ListAlertsRequest) (*a
 	if err != nil {
 		return nil, err
 	}
-	apiAlerts, err := convertAlerts(ctx, r, alerts)
+	apiAlerts, err := convertAlerts(ctx, r, system.ID, alerts)
 	if err != nil {
 		return nil, err
 	}
@@ -48,14 +48,14 @@ func GetAlert(ctx context.Context, r *Context, req *api.GetAlertRequest) (*api.A
 	if err != nil {
 		return nil, noRowsToNotFound(nil, fmt.Sprintf("alert %q in system %q", req.AlertId, req.SystemId))
 	}
-	apiAlert, err := convertAlerts(ctx, r, []db.Alert{alert})
+	apiAlert, err := convertAlerts(ctx, r, system.ID, []db.Alert{alert})
 	if err != nil {
 		return nil, err
 	}
 	return apiAlert[0], nil
 }
 
-func convertAlerts(ctx context.Context, r *Context, alerts []db.Alert) ([]*api.Alert, error) {
+func convertAlerts(ctx context.Context, r *Context, systemID string, alerts []db.Alert) ([]*api.Alert, error) {
 	var alertPks []int64
 	for _, alert := range alerts {
 		alertPks = append(alertPks, alert.Pk)
@@ -68,6 +68,8 @@ func convertAlerts(ctx context.Context, r *Context, alerts []db.Alert) ([]*api.A
 	for _, alert := range alerts {
 		apiAlerts = append(apiAlerts, &api.Alert{
 			Id:                  alert.ID,
+			Resource:            r.Reference.Alert(alert.ID, systemID, alert.Cause, alert.Effect).Resource,
+			System:              r.Reference.System(systemID),
 			Cause:               convert.AlertCause(alert.Cause),
 			Effect:              convert.AlertEffect(alert.Effect),
 			CurrentActivePeriod: currentActivePeriods[alert.Pk],

--- a/internal/public/endpoints/feed.go
+++ b/internal/public/endpoints/feed.go
@@ -45,6 +45,7 @@ func buildApiFeeds(r *Context, system *db.System, feeds []db.Feed) ([]*api.Feed,
 		apiFeeds = append(apiFeeds, &api.Feed{
 			Id:                     feed.ID,
 			System:                 r.Reference.System(system.ID),
+			Resource:               r.Reference.Feed(feed.ID, system.ID).Resource,
 			LastUpdateMs:           convert.SQLNullTimeMs(feed.LastUpdate),
 			LastSuccessfulUpdateMs: convert.SQLNullTimeMs(feed.LastSuccessfulUpdate),
 			LastSkippedUpdateMs:    convert.SQLNullTimeMs(feed.LastSkippedUpdate),

--- a/internal/public/endpoints/route.go
+++ b/internal/public/endpoints/route.go
@@ -85,6 +85,8 @@ func buildApiRoutes(ctx context.Context, r *Context, req routeRequest, routes []
 		route := &routes[i]
 		apiRoutes = append(apiRoutes, &api.Route{
 			Id:                route.ID,
+			Resource:          r.Reference.Route(route.ID, req.GetSystemId(), route.Color).Resource,
+			System:            r.Reference.System(req.GetSystemId()),
 			ShortName:         convert.SQLNullString(route.ShortName),
 			LongName:          convert.SQLNullString(route.LongName),
 			Color:             route.Color,

--- a/internal/public/endpoints/stop.go
+++ b/internal/public/endpoints/stop.go
@@ -145,6 +145,7 @@ func buildTransfersResponse(ctx context.Context, r *Context, systemID string, tr
 	for _, transfer := range transfers {
 		apiTransfers = append(apiTransfers, &api.Transfer{
 			Id:              transfer.ID,
+			System:          r.Reference.System(systemID),
 			FromStop:        stopPkToApiPreview[transfer.FromStopPk],
 			ToStop:          stopPkToApiPreview[transfer.ToStopPk],
 			Type:            convert.TransferType(transfer.Type),
@@ -213,6 +214,8 @@ func buildStopsResponse(ctx context.Context, r *Context, systemID string, stops 
 		}
 		result = append(result, &api.Stop{
 			Id:                 stop.ID,
+			System:             r.Reference.System(systemID),
+			Resource:           r.Reference.Stop(stop.ID, systemID, stop.Name).Resource,
 			Code:               convert.SQLNullString(stop.Code),
 			Name:               convert.SQLNullString(stop.Name),
 			Description:        convert.SQLNullString(stop.Description),

--- a/internal/public/endpoints/system.go
+++ b/internal/public/endpoints/system.go
@@ -60,6 +60,7 @@ func buildApiSystems(ctx context.Context, r *Context, systems []db.System) ([]*a
 		}
 		apiSystems = append(apiSystems, &api.System{
 			Id:        system.ID,
+			Resource:  r.Reference.System(system.ID).Resource,
 			Name:      system.Name,
 			Status:    api.System_Status(api.System_Status_value[strings.ToUpper(system.Status)]),
 			Agencies:  r.Reference.AgenciesChildResources(system.ID, numAgencies),


### PR DESCRIPTION
When testing with the API, I noted that the responses would come back missing the `resource` and `system` fields. This appeared to have been an omission, since they weren't being set in code. For my use case, this was breaking things as I need the system information specifically within each request. 

An example updated response is now: 

```json 
{
    "id": "1",
    "resource": {
        "path": "systems/us-ny-subway/routes/1"
    },
    "system": {
        "id": "us-ny-subway",
        "resource": {
            "path": "systems/us-ny-subway"
        }
    }
}
```

This PR just adds them to the relevant areas, although the only missing one is `Trip`'s `resource`, as generating that one requires significantly more data than feels sane to include for a basic piece of information. Specifically- it requires the routing information, and would increase the number of DB requests to a level that didn't feel worthwhile.

Furthermore, I will be filing a separate bug, since it looks like the MTA does something unique (as usual) with their Vehicle IDs where they are including forward slashes (`/`) in their IDs (e.g. `"$4 1418  UTI/WDL"`), which is breaking the pathing logic. Setting greedy wildcards in the proto breaks the List Vehicles endpoint, so that's not an option as well.  