### PR TITLE
Handle '/' characters in URL params

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -241,6 +241,8 @@ func newServeMux(logger *slog.Logger) *runtime.ServeMux {
 			}),
 		// Option to map internal errors to nice HTTP error
 		errors.ServeMuxOption(logger),
+		// Escape all URL characters except for /
+		runtime.WithUnescapingMode(runtime.UnescapingModeAllExceptSlash),
 	)
 }
 

--- a/tests/endtoend/README.md
+++ b/tests/endtoend/README.md
@@ -47,16 +47,16 @@ Steps:
    can also be run from your IDE, such as VSCode.
 
 **Advanced usage** The test assumes there is a running Transiter instance with
-an HTTP admin service listening at the location given in the environment
-variable `TRANSITER_HOST`. It also requires the source server to be running. The
-source server should be accessible to the test driver at the location
-`SOURCE_SERVER_HOST` and be accessible to the Transiter instance at the location
-`SOURCE_SERVER_HOST_WITHIN_TRANSITER`. The defaults for these are:
+an HTTP admin and public service listening at the locations given in the
+environment variables `TRANSITER_ADMIN_HOST` and `TRANSITER_PUBLIC_HOST`. It also
+requires the source server to be running. The source server should be accessible
+to the test driver at the location `SOURCE_SERVER_HOST` and be accessible to
+the Transiter instance at the location `SOURCE_SERVER_HOST_WITHIN_TRANSITER`.
+The defaults for these are:
 
-- `TRANSITER_HOST=http://localhost:8082` (this is also the Transiter default)
-
+- `TRANSITER_ADMIN_HOST=http://localhost:8082`
+- `TRANSITER_PUBLIC_HOST=http://localhost:8080`
 - `SOURCE_SERVER_HOST=http://localhost:8090`
-
 - `SOURCE_SERVER_HOST_WITHIN_TRANSITER=SOURCE_SERVER_HOST`
 
 So by default everything works without customization, but all of the

--- a/tests/endtoend/compose.yml
+++ b/tests/endtoend/compose.yml
@@ -35,6 +35,7 @@ services:
       context: ../..
       dockerfile: tests/endtoend/Dockerfile
     environment:
-      - TRANSITER_HOST=http://transiter:8082
+      - TRANSITER_ADMIN_HOST=http://transiter:8082
+      - TRANSITER_PUBLIC_HOST=http://transiter:8080
       - SOURCE_SERVER_HOST=http://sourceserver:8090
       - SOURCE_SERVER_HOST_WITHIN_TRANSITER=http://sourceserver:8090

--- a/tests/endtoend/fixtures/fixtures.go
+++ b/tests/endtoend/fixtures/fixtures.go
@@ -47,11 +47,18 @@ feeds:
 
 `
 
-func transiterHost() string {
-	if host, ok := os.LookupEnv("TRANSITER_HOST"); ok {
+func transiterAdminHost() string {
+	if host, ok := os.LookupEnv("TRANSITER_ADMIN_HOST"); ok {
 		return host
 	}
 	return "http://localhost:8082"
+}
+
+func transiterPublicHost() string {
+	if host, ok := os.LookupEnv("TRANSITER_PUBLIC_HOST"); ok {
+		return host
+	}
+	return "http://localhost:8080"
 }
 
 func sourceServerHostWithinTransiter() string {
@@ -62,8 +69,9 @@ func sourceServerHostWithinTransiter() string {
 }
 
 func GetTransiterClient(t *testing.T) *transiterclient.TransiterClient {
-	host := transiterHost()
-	client := transiterclient.NewTransiterClient(host)
+	publicHost := transiterPublicHost()
+	adminHost := transiterAdminHost()
+	client := transiterclient.NewTransiterClient(adminHost, publicHost)
 	if err := client.PingUntilOK(20); err != nil {
 		t.Fatalf("failed to ping Transiter: %v", err)
 	}

--- a/tests/endtoend/transiterclient/client.go
+++ b/tests/endtoend/transiterclient/client.go
@@ -12,12 +12,30 @@ import (
 )
 
 type TransiterClient struct {
+	// Currently active host
 	host string
+	// Host for the admin and public APIs
+	adminHost string
+	// Host for the public APIs
+	publicHost string
 }
 
-func NewTransiterClient(host string) *TransiterClient {
-	trimmedHost := strings.TrimSuffix(host, "/")
-	return &TransiterClient{host: trimmedHost}
+func NewTransiterClient(adminHost string, publicHost string) *TransiterClient {
+	trimmedAdminHost := strings.TrimSuffix(adminHost, "/")
+	trimmedPublicHost := strings.TrimSuffix(publicHost, "/")
+	return &TransiterClient{
+		host:       trimmedAdminHost,
+		adminHost:  trimmedAdminHost,
+		publicHost: trimmedPublicHost,
+	}
+}
+
+func (c *TransiterClient) UseAdminHost() {
+	c.host = c.adminHost
+}
+
+func (c *TransiterClient) UsePublicHost() {
+	c.host = c.publicHost
 }
 
 type QueryParam struct {

--- a/tests/endtoend/urlparsing_test.go
+++ b/tests/endtoend/urlparsing_test.go
@@ -1,0 +1,61 @@
+package endtoend
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/jamespfennell/transiter/tests/endtoend/fixtures"
+	"github.com/jamespfennell/transiter/tests/endtoend/testutils"
+	"github.com/jamespfennell/transiter/tests/endtoend/transiterclient"
+)
+
+type host string
+
+const (
+	adminHost  host = "admin"
+	publicHost host = "public"
+)
+
+func TestURLParsing(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		zipBuilder *testutils.ZipBuilder
+		test       func(t *testing.T, client *transiterclient.TransiterClient, systemID string)
+	}{
+		{
+			name: "stop with reserved url characters",
+			zipBuilder: fixtures.GTFSStaticDefaultZipBuilder().AddOrReplaceFile(
+				"stops.txt",
+				"stop_id,stop_name",
+				"$stop_1 / $%^?,Stop 1",
+			),
+			test: func(t *testing.T, client *transiterclient.TransiterClient, systemID string) {
+				gotStop, err := client.GetStop(systemID, EncodePathParam("$stop_1 / $%^?"))
+				if err != nil {
+					t.Fatalf("failed to get stop: %v", err)
+				}
+				testutils.AssertEqual(t, gotStop.ID, "$stop_1 / $%^?")
+				testutils.AssertEqual(t, gotStop.Name, "Stop 1")
+			},
+		},
+	} {
+		for _, host := range []host{adminHost, publicHost} {
+			testName := fmt.Sprintf("%s/%s/%s", "url_parsing", tc.name, host)
+			t.Run(testName, func(t *testing.T) {
+				systemID, _, _ := fixtures.InstallSystem(t, tc.zipBuilder.MustBuild())
+				transiterClient := fixtures.GetTransiterClient(t)
+				if host == adminHost {
+					transiterClient.UseAdminHost()
+				} else {
+					transiterClient.UsePublicHost()
+				}
+				tc.test(t, transiterClient, systemID)
+			})
+		}
+	}
+}
+
+func EncodePathParam(s string) string {
+	return url.PathEscape(s)
+}


### PR DESCRIPTION
- Based on the discussion in #149, this change configures the admin and public endpoints to not unescape a URL-encoded `/` character (`%2F`) before parsing path parameters. This allows for entities with the `/` character in their ID to be properly queried (e.g., a vehicle with ID `$2 0233+ FLA/241`, as is seen in the NYC Subway system). 
- Slightly modified `TransiterClient` and test infrastructure to allow for the client to switch between using the admin API and public API. This is useful for testing that common APIs behave the same on both endpoints.
- Add `urlparsing_test.go`, which contains a new end-do-end test that checks that reserved URL characters (including `/`) are properly handled in path params.