### PR TITLE
chore: add multi-platform build support to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-# (A) Build the Go binary
-FROM golang:1.22 AS builder
+# syntax=docker/dockerfile:1
+
+# (A) Prepare base & build the Go binary
+# Use the builder platform to cross-compile to the target platform.
+FROM --platform=${BUILDPLATFORM} golang:1.22-bookworm AS builder
 WORKDIR /transiter
 
-# (1) Install all the dependencies before copying in the source code.
-# This ensures that if we change the Go source code we don't have to redo all of
-# these (slow) steps again when building the Docker image, due to Docker's 
-# incremental caching.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "/usr/bin"
-COPY go.mod ./
-COPY go.sum ./
-RUN go mod download
-COPY justfile ./
+
+FROM builder AS codegen
 
 # (2) Next, we perform an optional step in which we re-generate all of the sqlc and
 # proto code and validate that it matches what's in source control.
@@ -18,7 +15,10 @@ COPY justfile ./
 # we're building actually reflects what's in the .proto and .sql files.
 
 # (2.1) Install all the code generation tools.
-RUN just install-tools
+COPY justfile .
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    just install-tools
 
 # (2.2) Generate the gRPC and DB files.
 COPY buf.gen.yaml .
@@ -44,13 +44,26 @@ RUN rm -r internal/genNew
 RUN diff --recursive docs/src/api docs/src/apiNew
 RUN rm -r docs/src/apiNew
 
-# (3) Build the binary.
-ARG TRANSITER_VERSION
-RUN just build ${TRANSITER_VERSION}
+FROM builder AS build
 
+# (3) Build the binary.
+# As soon as TARGETOS/TARGETARCH are defined, the build will differ
+# for each target platform during cross-compilation.
+ARG TRANSITER_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=bind,source=.,target=/transiter \
+    EXTRA_LDFLAGS='-w' EXTRA_GOFLAGS='-trimpath -o /out/transiter' \
+    just build ${TRANSITER_VERSION}
 
 # (B) Build the documentation
-FROM python:3.9 AS docs-builder
+# This is not platform-dependendent, so can be done once on the native
+# build platform and shared by all target platforms.
+FROM --platform=${BUILDPLATFORM} python:3.9 AS docs-builder
 WORKDIR /transiter
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "/usr/bin"
 COPY justfile ./
@@ -61,15 +74,15 @@ COPY docs/src docs/src
 RUN just docs
 
 
-# (C) Pull in the Caddy binary as a dependency
+# (C) Pull in the Caddy binary as a dependency (for the target platform).
 FROM caddy:2 AS caddy
 
 
 # (D) Put it all together.
 # We use this buildpack image because it already has SSL certificates installed
+# No emulation is required because there are no RUN statements.
 FROM buildpack-deps:bookworm-curl
-COPY --from=caddy /usr/bin/caddy /usr/bin
-COPY --from=docs-builder /transiter/docs/gen /usr/share/doc/transiter
-COPY --from=builder /transiter/transiter /usr/bin
+COPY --link --from=caddy /usr/bin/caddy /usr/bin/
+COPY --link --from=docs-builder /transiter/docs/gen /usr/share/doc/transiter
+COPY --link --from=build /out/transiter /usr/bin/
 ENTRYPOINT ["transiter"]
- 

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ default:
 
 # Build the Transiter binary and stamp it with the provided version
 build VERSION="":
-	go build --ldflags "-X github.com/jamespfennell/transiter/internal/version.version={{VERSION}}" .
+	go build --ldflags "-X github.com/jamespfennell/transiter/internal/version.version={{VERSION}} ${EXTRA_LDFLAGS:-}" ${EXTRA_GOFLAGS:-} .
 
 # Build the Transiter Docker image
 build-docker: _require-docker


### PR DESCRIPTION
This should help with #153 --

[`docker.io/milas/transiter:upstream`](https://hub.docker.com/layers/milas/transiter/upstream/images/sha256-21f7ca8fcb67301eb171c54ad6dc5dabe08813e8a0f98c8c2984339d49d17e07)
is a multi-platform arm64 / amd64 image built from HEAD:
```
docker buildx build --platform="linux/arm64,linux/amd64" -t milas/transiter:upstream .
```

Takes 42 seconds from scratch on my (admittedly fast) laptop.